### PR TITLE
Real menu pages for all five in-store kitchens

### DIFF
--- a/ClarksPNS/public/sitemap.xml
+++ b/ClarksPNS/public/sitemap.xml
@@ -2,6 +2,11 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url><loc>https://www.myclarkspns.com/</loc><changefreq>daily</changefreq><priority>1.0</priority></url>
   <url><loc>https://www.myclarkspns.com/food</loc><changefreq>weekly</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/food/krispy-krunchy</loc><changefreq>monthly</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/food/hangar-54</loc><changefreq>monthly</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/food/clarks-cafe</loc><changefreq>monthly</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/food/champs</loc><changefreq>monthly</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/food/coopers</loc><changefreq>monthly</changefreq></url>
   <url><loc>https://www.myclarkspns.com/clarks-rewards</loc><changefreq>monthly</changefreq></url>
   <url><loc>https://www.myclarkspns.com/car-wash</loc><changefreq>monthly</changefreq></url>
   <url><loc>https://www.myclarkspns.com/locations</loc><changefreq>daily</changefreq></url>

--- a/ClarksPNS/scripts/build-stores.mjs
+++ b/ClarksPNS/scripts/build-stores.mjs
@@ -21,8 +21,8 @@ const FOOD_MAP = {
   H54: 'Hangar 54',
   'Café': "Clark's Café",
   Cafe: "Clark's Café",
-  Champs: 'Champs Pizza',
-  Coopers: 'Coopers'
+  Champs: 'Champs Chicken',
+  Coopers: "Cooper's Express"
 }
 
 const kebab = s =>
@@ -123,6 +123,11 @@ writeFileSync(
 const staticUrls = [
   { loc: '/', changefreq: 'daily', priority: '1.0' },
   { loc: '/food', changefreq: 'weekly' },
+  { loc: '/food/krispy-krunchy', changefreq: 'monthly' },
+  { loc: '/food/hangar-54', changefreq: 'monthly' },
+  { loc: '/food/clarks-cafe', changefreq: 'monthly' },
+  { loc: '/food/champs', changefreq: 'monthly' },
+  { loc: '/food/coopers', changefreq: 'monthly' },
   { loc: '/clarks-rewards', changefreq: 'monthly' },
   { loc: '/car-wash', changefreq: 'monthly' },
   { loc: '/locations', changefreq: 'daily' },

--- a/ClarksPNS/src/App.tsx
+++ b/ClarksPNS/src/App.tsx
@@ -12,6 +12,7 @@ import ClarksRewards from '@/pages/clarksrewards'
 import CarWash from '@/pages/CarWash'
 import Locations from '@/pages/Locations'
 import StoreDetail from '@/pages/StoreDetail'
+import FoodBrand from '@/pages/FoodBrand'
 import Careers from '@/pages/Careers'
 import Terms from '@/pages/Terms'
 import Privacy from '@/pages/Privacy'
@@ -41,6 +42,7 @@ export default function App () {
           <Route path='/about-us' element={<About />} />
           <Route path='/Charity' element={<Charity />} />
           <Route path='/Food' element={<Food />} />
+          <Route path='/food/:slug' element={<FoodBrand />} />
           <Route path='/Careers' element={<Careers />} />
           <Route path='/terms' element={<Terms />} />
           <Route path='/privacy' element={<Privacy />} />

--- a/ClarksPNS/src/content/menus.ts
+++ b/ClarksPNS/src/content/menus.ts
@@ -1,0 +1,357 @@
+// Typed menus for Clark's in-store kitchens, transcribed from the printed
+// menu boards in src/assets/images/menus/. Prices/items change in-store first —
+// update here when new boards ship.
+
+export type MenuItem = {
+  name: string
+  price?: string
+  note?: string
+}
+
+export type MenuSection = {
+  title: string
+  note?: string
+  items: MenuItem[]
+}
+
+export type FoodBrandDef = {
+  slug: string
+  name: string
+  /** kitchen name as it appears in stores.index.json (for store matching) */
+  kitchenName: string
+  tagline: string
+  blurb: string
+  /** brand folder under src/assets/images/menus/ (menu-board photos) */
+  menuAssetKey: string
+  sections: MenuSection[]
+}
+
+export const FOOD_BRANDS: FoodBrandDef[] = [
+  {
+    slug: 'krispy-krunchy',
+    name: 'Krispy Krunchy Chicken',
+    kitchenName: 'Krispy Krunchy Chicken',
+    tagline: 'Freshly made. Perfectly Cajun.',
+    blurb:
+      'Hand-breaded Louisiana-style chicken, jumbo tenders, honey biscuits, and Cajun sides — cooked fresh throughout the day.',
+    menuAssetKey: 'krispy-krunchy',
+    sections: [
+      {
+        title: 'Hand-Breaded Chicken',
+        note: 'Krunch Box includes a regular side + biscuit',
+        items: [
+          { name: '2 pc Krunch Box', price: '$7.99' },
+          { name: '3 pc Krunch Box', price: '$9.99' },
+          { name: '4 pc Krunch Box', price: '$11.99' },
+          { name: '2 pc Chicken + Biscuit', price: '$5.99' },
+          { name: '3 pc Chicken + Biscuit', price: '$7.99' },
+          { name: '4 pc Chicken + Biscuit', price: '$9.99' }
+        ]
+      },
+      {
+        title: 'Hand-Breaded Jumbo Tenders',
+        note: 'Krunch Box includes a regular side + biscuit',
+        items: [
+          { name: '3 pc Krunch Box', price: '$9.49' },
+          { name: '4 pc Krunch Box', price: '$10.99' },
+          { name: '6 pc Krunch Box', price: '$13.99' },
+          { name: '3 pc Tenders + Biscuit', price: '$7.49' },
+          { name: '4 pc Tenders + Biscuit', price: '$8.99' },
+          { name: '6 pc Tenders + Biscuit', price: '$11.99' }
+        ]
+      },
+      {
+        title: 'Chicken Nuggets',
+        items: [
+          { name: '6 pc Krunch Box', price: '$6.99', note: 'regular side + biscuit' },
+          { name: '10 pc Krunch Box', price: '$8.99', note: 'regular side + biscuit' },
+          { name: '6 pc Nuggets + Biscuit', price: '$5.49' },
+          { name: '10 pc Nuggets + Biscuit', price: '$7.49' }
+        ]
+      },
+      {
+        title: 'Sandwich, Wings & Shrimp',
+        items: [
+          { name: 'Cajun Chicken Sandwich Krunch Box', price: '$7.39', note: 'regular side' },
+          { name: 'Cajun Chicken Sandwich Only', price: '$5.39' },
+          { name: '5 pc Traditional Wings', price: '$8.99', note: 'Krispy, Buffalo or Sweet & Sour' },
+          { name: '10 pc Traditional Wings', price: '$16.99' },
+          { name: '20 pc Traditional Wings', price: '$30.99' },
+          { name: '5 pc Honey Butter Shrimp', price: '$5.39' },
+          { name: '10 pc Honey Butter Shrimp', price: '$8.59' }
+        ]
+      },
+      {
+        title: 'Family Meals',
+        items: [
+          {
+            name: 'Chicken + Tenders Family Meal',
+            price: '$43.99',
+            note: '12 pc chicken, 6 tenders, 6 biscuits & family wedges'
+          },
+          { name: 'Chicken Family Meal', price: '$27.99', note: '12 pc chicken, 6 biscuits & family wedges' },
+          { name: 'Tenders Family Meal', price: '$29.99', note: '12 tenders, 6 biscuits & family wedges' },
+          { name: '8 pc Chicken', price: '$17.99' },
+          { name: '12 pc Chicken', price: '$23.99' },
+          { name: '16 pc Chicken', price: '$29.99' },
+          { name: '8 pc Tenders', price: '$14.99' },
+          { name: '12 pc Tenders', price: '$22.99' },
+          { name: '16 pc Tenders', price: '$27.99' }
+        ]
+      },
+      {
+        title: 'Sides & Biscuits',
+        note: 'Dipping sauces: Signature Krunch, Ranch, Sweet & Sour, Barbecue, Honey Mustard, Buffalo',
+        items: [
+          { name: 'Mashed Potatoes & Gravy', price: '$2.79 / $4.99', note: 'regular / large' },
+          { name: 'Mac & Cheese', price: '$2.79 / $4.99', note: 'regular / large' },
+          { name: 'Jambalaya', price: '$2.79 / $4.99', note: 'regular / large' },
+          { name: 'Red Beans & Rice', price: '$2.79 / $4.99', note: 'regular / large' },
+          { name: 'Wedges', price: '$1.99 / $3.99 / $4.99', note: 'regular / large / family' },
+          { name: 'Honey Biscuits', price: '$0.99 / $1.99 / $4.99', note: '1 / 2 / 6' },
+          { name: 'Extra Dipping Sauce', price: '$0.69' }
+        ]
+      }
+    ]
+  },
+  {
+    slug: 'hangar-54',
+    name: 'Hangar 54 Pizza',
+    kitchenName: 'Hangar 54',
+    tagline: 'Hot from the oven — slices and whole pies.',
+    blurb:
+      'Fresh-made pizza in two sizes: grab a 7" personal for the road or a 14" pie for the crew. Breakfast pizza in the morning, First Class combos all day.',
+    menuAssetKey: 'hangar54',
+    sections: [
+      {
+        title: '1-Topping Pizzas',
+        note: '14" $12.00 · 7" personal $4.99',
+        items: [
+          { name: '5 Cheese Blend' },
+          { name: 'Pepperoni' },
+          { name: 'Italian Sausage' },
+          { name: 'Bacon' },
+          { name: 'Chicken' }
+        ]
+      },
+      {
+        title: 'First Class Pizzas',
+        note: '14" $15.00 · 7" personal $5.99',
+        items: [
+          { name: '3 Meat Pizza', note: 'pepperoni, Italian sausage & bacon' },
+          { name: 'BBQ Chicken' },
+          { name: 'Buffalo Chicken' },
+          { name: 'Chicken Bacon Ranch' },
+          { name: "You're the Pilot", note: 'pick up to 5 toppings' }
+        ]
+      },
+      {
+        title: 'Breakfast Pizza',
+        note: 'Fuel your breakfast — mornings only',
+        items: [
+          {
+            name: 'Sausage Gravy with Bacon, Egg & Cheese',
+            price: '14" $15.00 · 7" $5.99'
+          }
+        ]
+      },
+      {
+        title: 'Extras',
+        items: [{ name: 'Sauce Cup — dip, dunk or drizzle', price: '$0.69' }]
+      }
+    ]
+  },
+  {
+    slug: 'clarks-cafe',
+    name: "Clark's Café",
+    kitchenName: "Clark's Café",
+    tagline: 'Freshly made, just for you.',
+    blurb:
+      'Scratch breakfast served hot: biscuits and gravy, breakfast sandwiches stacked your way, omelets, and coffee to match.',
+    menuAssetKey: 'clarks-cafe',
+    sections: [
+      {
+        title: 'Café Favorites',
+        items: [
+          {
+            name: 'Café Special',
+            price: '$5.99',
+            note: '2 eggs, 1 biscuit with gravy, 1 sausage or 3 bacon strips'
+          },
+          { name: 'Egg Breakfast — 1 egg', price: '$3.99', note: 'choice of meat, biscuit or toast' },
+          { name: 'Egg Breakfast — 2 eggs', price: '$4.99', note: 'choice of meat, biscuit or toast' },
+          { name: 'Loaded Breakfast Burrito', price: '$3.59' },
+          { name: 'Omelet with Cheese', price: '$2.99' },
+          { name: 'Omelet with Meat & Cheese', price: '$3.99' },
+          { name: 'Biscuit & Gravy', price: '$2.29' },
+          { name: '2 Biscuits & Gravy', price: '$3.29' },
+          { name: 'BLT on Toast — 3 bacon', price: '$3.59' },
+          { name: 'BLT on Toast — 6 bacon', price: '$5.29' }
+        ]
+      },
+      {
+        title: 'Biscuits & Toast',
+        note: 'On a fresh biscuit or toast — add egg or cheese to any',
+        items: [
+          { name: 'Egg', price: '$1.99' },
+          { name: 'Sausage Patty', price: '$2.59', note: '+ egg $3.09 · + egg & cheese $3.49' },
+          { name: '3 Bacon Strips', price: '$2.99', note: '+ egg $3.49 · + egg & cheese $3.89' },
+          { name: 'Ham', price: '$2.49', note: '+ egg $3.19 · + egg & cheese $3.59' },
+          { name: 'Chicken Strip', price: '$2.79', note: '+ egg $3.49 · + egg & cheese $3.89' },
+          { name: 'Pork Tenderloin', price: '$3.69', note: '+ egg $3.89 · + egg & cheese $4.29' },
+          { name: 'Bologna', price: '$2.99', note: '+ egg & cheese $3.79' },
+          { name: 'Breaded Beef Steak', price: '$3.49', note: '+ egg $3.99 · + egg & cheese $4.39' },
+          { name: 'Split Smoked Sausage', price: '$2.99', note: '+ egg $3.69 · + egg & cheese $4.09' },
+          { name: 'Big T', price: '$2.99' }
+        ]
+      },
+      {
+        title: 'Sides & Extras',
+        items: [
+          { name: 'Hashbrown', price: '$1.49' },
+          { name: 'Ham & Cheese Stuffed Hashbrown', price: '$3.29' },
+          { name: 'Sausage & Gravy Stuffed Hashbrown', price: '$3.29' },
+          { name: 'Sausage, Egg & Cheese Stuffed Waffle', price: '$3.29' },
+          { name: 'Blueberry Pancake on a Stick', price: '$1.99' },
+          { name: 'Biscuit', price: '$1.19' },
+          { name: 'Toast Slice', price: '$0.99' },
+          { name: 'Egg', price: '$1.09' },
+          { name: 'Gravy', price: '$1.29' },
+          { name: 'Cheese', price: '$0.59' }
+        ]
+      }
+    ]
+  },
+  {
+    slug: 'champs',
+    name: 'Champs Chicken',
+    kitchenName: 'Champs Chicken',
+    tagline: 'Be a mealtime hero.',
+    blurb:
+      'Crispy tenders, the Real Champ sandwich, seafood boxes, and homestyle sides — every box comes with battered fries and Sassy Sauce.',
+    menuAssetKey: 'champs',
+    sections: [
+      {
+        title: 'Chicken Boxes',
+        note: 'Every box includes battered fries & Sassy Sauce',
+        items: [
+          { name: 'The Real Champ Sandwich Box', price: '$7.99', note: 'sandwich only $5.99' },
+          { name: '2 pc Tenders Box', price: '$6.99', note: 'chicken only $3.99' },
+          { name: '3 pc Tenders Box', price: '$8.79', note: 'chicken only $5.99' },
+          { name: '8 pc Dippers Box', price: '$7.49', note: 'chicken only $5.49' }
+        ]
+      },
+      {
+        title: 'Seafood Boxes',
+        items: [
+          { name: '1 pc Fish Box', price: '$6.99', note: 'fish only $4.99' },
+          { name: '6 pc Shrimp Box', price: '$8.99', note: 'shrimp only $6.99' }
+        ]
+      },
+      {
+        title: 'Bone-In Favorites',
+        items: [
+          { name: 'Livers Box', price: '$6.49', note: 'chicken only $4.99' },
+          { name: 'Gizzards Box', price: '$6.49', note: 'chicken only $4.99' }
+        ]
+      },
+      {
+        title: 'Bowls & Family Meals',
+        items: [
+          {
+            name: 'Dipper Bowl',
+            price: '$7.49',
+            note: 'dippers, mashed potatoes, corn, gravy & cheese'
+          },
+          {
+            name: '8 pc Tenders Family Meal',
+            price: '$29.99',
+            note: 'serves 4 — 2 large sides & 4 biscuits'
+          },
+          { name: 'Family Meal — Chicken Only', price: '$16.99' }
+        ]
+      },
+      {
+        title: 'Sides',
+        note: 'Make any box a BIG box (+1 regular side & biscuit) for $3.00',
+        items: [
+          { name: 'French Fries', price: '$2.49 / $5.49', note: 'regular / large' },
+          { name: 'Potato Wedges', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Mac & Cheese', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Mashed Potatoes', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Sweet Corn', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Green Beans', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Hushpuppies', price: '$2.99 / $5.99', note: 'regular / large' }
+        ]
+      }
+    ]
+  },
+  {
+    slug: 'coopers',
+    name: "Cooper's Express",
+    kitchenName: "Cooper's Express",
+    tagline: 'Big & juicy, famous fried chicken.',
+    blurb:
+      'The Big & Juicy chicken sandwich, tenders, crispy fish, and local favorites like livers and gizzards — boxes come with battered fries and dipping sauce.',
+    menuAssetKey: 'coopers',
+    sections: [
+      {
+        title: 'Chicken Boxes',
+        note: 'Every box includes battered fries & dipping sauce',
+        items: [
+          { name: 'Big & Juicy Chicken Sandwich Box', price: '$7.99', note: 'sandwich only $5.99' },
+          { name: '2 pc Tenders Box', price: '$6.99', note: 'chicken only $3.99' },
+          { name: '3 pc Tenders Box', price: '$8.79', note: 'chicken only $5.99' },
+          { name: '8 pc Dippers Box', price: '$7.49', note: 'chicken only $5.49' }
+        ]
+      },
+      {
+        title: 'Seafood Boxes',
+        items: [
+          { name: '1 pc Crispy Fish Box', price: '$6.99', note: 'fish only $4.99' },
+          { name: '6 pc Shrimp Box', price: '$8.99', note: 'shrimp only $6.99' }
+        ]
+      },
+      {
+        title: 'Local Favorites',
+        items: [
+          { name: 'Livers Box', price: '$6.49', note: 'chicken only $4.49' },
+          { name: 'Gizzards Box', price: '$6.49', note: 'chicken only $4.49' }
+        ]
+      },
+      {
+        title: 'Bowls & Family Meals',
+        items: [
+          {
+            name: 'Dipper Bowl',
+            price: '$7.49',
+            note: 'dippers, mashed potatoes, corn, gravy & cheese'
+          },
+          {
+            name: '8 Tenders Family Meal',
+            price: '$29.99',
+            note: 'serves 4 — 2 large sides, 4 biscuits & sauce'
+          },
+          { name: 'Family Meal — Chicken Only & Sauce', price: '$16.99' }
+        ]
+      },
+      {
+        title: 'Sides',
+        note: 'Make any box a BIG box (+1 regular side & biscuit) for $3.00',
+        items: [
+          { name: 'Battered Fries', price: '$2.49 / $5.49', note: 'regular / large' },
+          { name: 'Potato Wedges', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Mac & Cheese', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Mashed Potatoes', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Sweet Corn', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Green Beans', price: '$2.99 / $5.99', note: 'regular / large' },
+          { name: 'Hushpuppies', price: '$2.99 / $5.99', note: 'regular / large' }
+        ]
+      }
+    ]
+  }
+]
+
+export function getBrandBySlug(slug?: string): FoodBrandDef | undefined {
+  return FOOD_BRANDS.find(b => b.slug === slug)
+}

--- a/ClarksPNS/src/content/stores.index.json
+++ b/ClarksPNS/src/content/stores.index.json
@@ -564,7 +564,7 @@
     "kitchens": [
       {
         "code": "Champs",
-        "name": "Champs Pizza"
+        "name": "Champs Chicken"
       },
       {
         "code": "GG",
@@ -2931,7 +2931,7 @@
     "kitchens": [
       {
         "code": "Coopers",
-        "name": "Coopers"
+        "name": "Cooper's Express"
       },
       {
         "code": "GG",
@@ -3311,7 +3311,7 @@
       },
       {
         "code": "Champs",
-        "name": "Champs Pizza"
+        "name": "Champs Chicken"
       },
       {
         "code": "H54",
@@ -3384,7 +3384,7 @@
     "kitchens": [
       {
         "code": "Champs",
-        "name": "Champs Pizza"
+        "name": "Champs Chicken"
       },
       {
         "code": "GG",
@@ -3671,7 +3671,7 @@
     "kitchens": [
       {
         "code": "Coopers",
-        "name": "Coopers"
+        "name": "Cooper's Express"
       }
     ],
     "hours": {

--- a/ClarksPNS/src/pages/Food.tsx
+++ b/ClarksPNS/src/pages/Food.tsx
@@ -1,5 +1,6 @@
 // src/pages/Food.tsx
 import React from 'react'
+import { Link } from 'react-router-dom'
 import champsLogo from '@/assets/images/champschickenlogo.png'
 import hangarLogo from '@/assets/images/Hangar54Logo_02-1.png'
 import jacksLogo from '@/assets/images/jacksdelilogo.webp'
@@ -279,6 +280,15 @@ function MenusDiagnostics() {
 }
 
 
+/** Brands with a dedicated menu page at /food/<slug> */
+const MENU_PAGE_SLUG: Record<string, string> = {
+  champs: 'champs',
+  hangar54: 'hangar-54',
+  'clarks-cafe': 'clarks-cafe',
+  'krispy-krunchy': 'krispy-krunchy',
+  coopers: 'coopers'
+}
+
 function MenuBlock ({
   id,
   brandKey,
@@ -293,14 +303,7 @@ function MenuBlock ({
   desc: string
 }) {
   const { pdfs, images } = collectMenus(brandKey)
-// TEMP DEBUG (use log, not debug)
-console.log('[menus]', {
-  brandKey,
-  pdfsCount: pdfs.length,
-  imagesCount: images.length,
-  sampleImageKeys: Object.keys(MENU_IMAGES).slice(0, 5),
-  samplePdfKeys: Object.keys(MENU_PDFS).slice(0, 5),
-})
+  const menuPage = MENU_PAGE_SLUG[brandKey]
   const [lightbox, setLightbox] = React.useState<string | null>(null)
 
   // Accordion state (collapsed by default). Auto-open if URL hash matches this block's id.
@@ -360,6 +363,16 @@ console.log('[menus]', {
       >
         <div className='overflow-hidden'>
           <div className='px-6 pb-6 space-y-4'>
+            {/* Full menu page */}
+            {menuPage && (
+              <Link
+                to={`/food/${menuPage}`}
+                className='inline-flex items-center justify-center rounded-xl px-4 py-2 bg-brand text-white hover:bg-brand/90 transition-colors'
+              >
+                View full menu →
+              </Link>
+            )}
+
             {/* PDFs */}
             {pdfs.length ? (
               <div className='flex flex-wrap gap-2'>
@@ -375,9 +388,9 @@ console.log('[menus]', {
                   </a>
                 ))}
               </div>
-            ) : (
+            ) : !menuPage ? (
               <p className='text-black/60 text-sm'>Menu PDF coming soon.</p>
-            )}
+            ) : null}
 
             {/* Images */}
             {images.length ? (

--- a/ClarksPNS/src/pages/FoodBrand.tsx
+++ b/ClarksPNS/src/pages/FoodBrand.tsx
@@ -1,0 +1,290 @@
+// Per-kitchen menu page: /food/:slug
+// Real typed menu (from src/content/menus.ts) + the printed menu boards in a
+// lightbox + every store that carries this kitchen, linked to its store page.
+import React from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { SEO } from '@/lib/seo'
+import { getBrandBySlug, FOOD_BRANDS } from '@/content/menus'
+import { allStores, namedKitchens, type Store } from '@/lib/stores'
+
+import champsLogo from '@/assets/images/champschickenlogo.png'
+import hangarLogo from '@/assets/images/Hangar54Logo_02-1.png'
+import cafeLogo from '@/assets/images/clarkscafelogo.webp'
+import kkcLogo from '@/assets/images/krispykrunchychickenlogo.webp'
+import coopersLogo from '@/assets/images/CoopersExpressLogo.png'
+
+const LOGO: Record<string, string> = {
+  'krispy-krunchy': kkcLogo,
+  'hangar-54': hangarLogo,
+  'clarks-cafe': cafeLogo,
+  champs: champsLogo,
+  coopers: coopersLogo
+}
+
+// Menu-board photos, keyed by brand folder (same assets the Food page uses)
+const MENU_BOARD_IMAGES = import.meta.glob(
+  '@/assets/images/menus/**/*.{jpg,jpeg,png,webp,avif}',
+  { eager: true, as: 'url' }
+) as Record<string, string>
+
+function boardsFor(assetKey: string): string[] {
+  return Object.entries(MENU_BOARD_IMAGES)
+    .filter(([path]) => path.toLowerCase().includes(`/menus/${assetKey}/`))
+    .map(([, url]) => url)
+    .sort()
+}
+
+function Eyebrow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+      {children}
+    </div>
+  )
+}
+
+export default function FoodBrand() {
+  const { slug } = useParams<{ slug: string }>()
+  const brand = getBrandBySlug(slug)
+
+  React.useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [slug])
+
+  if (!brand) {
+    return (
+      <main className='w-full bg-white'>
+        <SEO title='Menu not found — Clark’s Pump-N-Shop' robots='noindex,nofollow' />
+        <div className='container mx-auto px-6 py-24 text-center md:px-10'>
+          <h1 className="font-['Oswald'] text-4xl font-bold text-black">
+            Menu not found
+          </h1>
+          <p className='mt-3 text-black/70'>
+            That kitchen isn’t on our menu board.
+          </p>
+          <Link
+            to='/food'
+            className='mt-6 inline-flex items-center justify-center rounded-2xl bg-brand px-5 py-3 text-white hover:bg-brand/90'
+          >
+            See all food
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  const stores = allStores.filter(s =>
+    namedKitchens(s).includes(brand.kitchenName)
+  )
+  const boards = boardsFor(brand.menuAssetKey)
+  const logo = LOGO[brand.slug]
+
+  return (
+    <main className='w-full overflow-x-clip bg-white'>
+      <SEO
+        title={`${brand.name} Menu — Clark’s Pump-N-Shop`}
+        description={`${brand.blurb} Available inside ${stores.length} Clark’s Pump-N-Shop location${stores.length === 1 ? '' : 's'}.`}
+        path={`/food/${brand.slug}`}
+      />
+
+      {/* Header */}
+      <section className='bg-gradient-to-br from-white via-white to-neutral-50'>
+        <div className='container mx-auto px-6 pt-8 md:px-10'>
+          <nav className='text-sm text-black/60'>
+            <Link to='/' className='hover:text-brand'>Home</Link>
+            <span className='px-2'>/</span>
+            <Link to='/food' className='hover:text-brand'>Food</Link>
+            <span className='px-2'>/</span>
+            <span className='text-black'>{brand.name}</span>
+          </nav>
+
+          <div className='flex flex-col items-start gap-6 py-8 md:flex-row md:items-center md:justify-between md:py-12'>
+            <div>
+              <Eyebrow>In-store kitchen</Eyebrow>
+              <h1 className="mt-1 font-['Oswald'] text-4xl font-bold leading-tight text-black md:text-6xl">
+                {brand.name}
+              </h1>
+              <div className='mt-4 h-1 w-40 rounded bg-brand' />
+              <p className='mt-4 max-w-prose text-lg text-black/70 md:text-xl'>
+                {brand.blurb}
+              </p>
+            </div>
+            {logo && (
+              <img
+                src={logo}
+                alt={`${brand.name} logo`}
+                className='h-20 w-auto object-contain md:h-28'
+              />
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* Menu */}
+      <section className='container mx-auto px-6 py-10 md:px-10'>
+        <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
+          {brand.sections.map(section => (
+            <div
+              key={section.title}
+              className='rounded-2xl border border-black/10 bg-white p-6 shadow-soft'
+            >
+              <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+                {section.title}
+              </h2>
+              {section.note && (
+                <p className='mt-1 text-sm text-black/60'>{section.note}</p>
+              )}
+              <ul className='mt-4 divide-y divide-black/5'>
+                {section.items.map(item => (
+                  <li
+                    key={item.name}
+                    className='flex items-baseline justify-between gap-4 py-2.5'
+                  >
+                    <div className='min-w-0'>
+                      <span className='font-medium text-black'>{item.name}</span>
+                      {item.note && (
+                        <span className='block text-sm text-black/60'>
+                          {item.note}
+                        </span>
+                      )}
+                    </div>
+                    {item.price && (
+                      <span className='shrink-0 font-semibold text-black'>
+                        {item.price}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <p className='mt-6 text-sm text-black/50'>
+          Prices and availability may vary by location. Nutrition information
+          available in store.
+        </p>
+      </section>
+
+      {/* Menu boards */}
+      {boards.length > 0 && <MenuBoards name={brand.name} boards={boards} />}
+
+      {/* Stores with this kitchen */}
+      <section className='bg-surface-alt py-12'>
+        <div className='container mx-auto px-6 md:px-10'>
+          <Eyebrow>Find it near you</Eyebrow>
+          <h2 className="mt-1 font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+            {brand.name} is inside {stores.length} Clark’s location
+            {stores.length === 1 ? '' : 's'}.
+          </h2>
+          <div className='mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+            {stores.map(s => (
+              <StoreCard key={s.slug} store={s} />
+            ))}
+          </div>
+          <div className='mt-8'>
+            <Link
+              to='/locations'
+              className='inline-flex items-center justify-center rounded-2xl bg-brand px-5 py-3 text-white transition-colors hover:bg-brand/90'
+            >
+              See all locations
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Other kitchens */}
+      <section className='container mx-auto px-6 py-12 md:px-10'>
+        <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+          More from our kitchens
+        </h2>
+        <div className='mt-4 flex flex-wrap gap-3'>
+          {FOOD_BRANDS.filter(b => b.slug !== brand.slug).map(b => (
+            <Link
+              key={b.slug}
+              to={`/food/${b.slug}`}
+              className='rounded-2xl border border-black/10 bg-white px-4 py-2.5 font-medium text-black transition-colors hover:border-brand hover:text-brand'
+            >
+              {b.name}
+            </Link>
+          ))}
+        </div>
+      </section>
+    </main>
+  )
+}
+
+function StoreCard({ store }: { store: Store }) {
+  return (
+    <Link
+      to={`/locations/${store.slug}`}
+      className='group rounded-2xl border border-black/10 bg-white p-5 shadow-soft transition-shadow hover:shadow-md'
+    >
+      <div className="font-['Oswald'] text-lg font-bold text-black group-hover:text-brand">
+        {store.name}
+      </div>
+      <div className='mt-1 text-sm text-black/70'>
+        {store.address}, {store.city}, {store.state}
+      </div>
+      <div className='mt-3 text-sm font-medium text-brand'>View store →</div>
+    </Link>
+  )
+}
+
+function MenuBoards({ name, boards }: { name: string; boards: string[] }) {
+  const [lightbox, setLightbox] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    if (!lightbox) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setLightbox(null)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [lightbox])
+
+  return (
+    <section className='container mx-auto px-6 pb-4 md:px-10'>
+      <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+        The menu board
+      </h2>
+      <div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2'>
+        {boards.map(src => (
+          <button
+            key={src}
+            type='button'
+            onClick={() => setLightbox(src)}
+            className='overflow-hidden rounded-2xl border border-black/10 bg-white transition-shadow hover:shadow-md'
+            title={`${name} menu board`}
+          >
+            <img
+              src={src}
+              alt={`${name} menu board`}
+              loading='lazy'
+              className='h-auto w-full object-contain'
+            />
+          </button>
+        ))}
+      </div>
+
+      {lightbox && (
+        <div
+          className='fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4'
+          onClick={() => setLightbox(null)}
+        >
+          <img
+            src={lightbox}
+            alt={`${name} menu board — full view`}
+            className='max-h-[92vh] w-auto max-w-full rounded-xl object-contain'
+          />
+          <button
+            type='button'
+            onClick={() => setLightbox(null)}
+            className='absolute right-4 top-4 rounded-full bg-brand px-3 py-1 text-white shadow-lg'
+            aria-label='Close menu board'
+          >
+            ✕
+          </button>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/ClarksPNS/src/pages/StoreDetail.tsx
+++ b/ClarksPNS/src/pages/StoreDetail.tsx
@@ -4,6 +4,7 @@ import { SEO } from '@/lib/seo'
 import FindUsMap from '@/components/site/FindUsMap'
 import StoreGallery from '@/components/site/StoreGallery'
 import storeMedia from '@/content/store-media.json'
+import { FOOD_BRANDS } from '@/content/menus'
 import {
   DAY_LABEL,
   DAY_ORDER,
@@ -210,14 +211,31 @@ export default function StoreDetail() {
                   <h2 className="mt-1 font-['Oswald'] text-2xl font-bold text-black md:text-3xl">Hot, fresh, and fast.</h2>
                   <p className='mt-1 text-black/70'>Made-to-order, right inside this location.</p>
                   <div className='mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2'>
-                    {kitchens.map(k => (
-                      <div key={k} className='flex items-center gap-3 rounded-xl border border-black/10 bg-surface-alt p-3'>
-                        <span className='grid h-11 w-11 flex-none place-items-center rounded-lg bg-brand text-sm font-bold text-white'>
-                          {k.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase()}
-                        </span>
-                        <span className='font-medium text-black'>{k}</span>
-                      </div>
-                    ))}
+                    {kitchens.map(k => {
+                      const brand = FOOD_BRANDS.find(b => b.kitchenName === k)
+                      const inner = (
+                        <>
+                          <span className='grid h-11 w-11 flex-none place-items-center rounded-lg bg-brand text-sm font-bold text-white'>
+                            {k.split(' ').map(w => w[0]).join('').slice(0, 2).toUpperCase()}
+                          </span>
+                          <span className='min-w-0 grow font-medium text-black'>{k}</span>
+                          {brand && <span className='shrink-0 text-sm font-medium text-brand'>Menu →</span>}
+                        </>
+                      )
+                      return brand ? (
+                        <Link
+                          key={k}
+                          to={`/food/${brand.slug}`}
+                          className='flex items-center gap-3 rounded-xl border border-black/10 bg-surface-alt p-3 transition-colors hover:border-brand'
+                        >
+                          {inner}
+                        </Link>
+                      ) : (
+                        <div key={k} className='flex items-center gap-3 rounded-xl border border-black/10 bg-surface-alt p-3'>
+                          {inner}
+                        </div>
+                      )
+                    })}
                   </div>
                 </div>
               )}


### PR DESCRIPTION
Dedicated pages at /food/krispy-krunchy, /food/hangar-54, /food/clarks-cafe, /food/champs, /food/coopers. Each has the full menu transcribed from the printed boards (indexable by Google, unlike the photos), the board photos in a lightbox, and a 'find it near you' grid of every store carrying that kitchen. Food page cards and store-page kitchen tiles link in. Also corrects kitchen names in the data (Champs Chicken, Cooper's Express).

🤖 Generated with [Claude Code](https://claude.com/claude-code)