### PR TITLE
Experience pages: Your Clark's, Beer Cave, Car Wash, heritage timeline, specials marquee

### DIFF
--- a/ClarksPNS/src/App.tsx
+++ b/ClarksPNS/src/App.tsx
@@ -13,6 +13,7 @@ import CarWash from '@/pages/CarWash'
 import Locations from '@/pages/Locations'
 import StoreDetail from '@/pages/StoreDetail'
 import FoodBrand from '@/pages/FoodBrand'
+import BeerCave from '@/pages/BeerCave'
 import Careers from '@/pages/Careers'
 import Terms from '@/pages/Terms'
 import Privacy from '@/pages/Privacy'
@@ -43,6 +44,7 @@ export default function App () {
           <Route path='/Charity' element={<Charity />} />
           <Route path='/Food' element={<Food />} />
           <Route path='/food/:slug' element={<FoodBrand />} />
+          <Route path='/beer-cave' element={<BeerCave />} />
           <Route path='/Careers' element={<Careers />} />
           <Route path='/terms' element={<Terms />} />
           <Route path='/privacy' element={<Privacy />} />

--- a/ClarksPNS/src/components/site/YourClarks.tsx
+++ b/ClarksPNS/src/components/site/YourClarks.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { allStores, milesBetween, openNow, type Store } from '@/lib/stores'
+
+// "Your Clark's" — homepage personalization band. Quietly asks for the
+// visitor's location and shows their nearest store with live open/closed
+// status and distance. Renders nothing until a location is available, so
+// declining the prompt simply means no band.
+
+type Nearest = { store: Store; miles: number }
+
+export default function YourClarks() {
+  const [nearest, setNearest] = useState<Nearest | null>(null)
+
+  useEffect(() => {
+    if (!('geolocation' in navigator)) return
+    navigator.geolocation.getCurrentPosition(
+      pos => {
+        const here = { lat: pos.coords.latitude, lng: pos.coords.longitude }
+        let best: Nearest | null = null
+        for (const s of allStores) {
+          if (s.lat == null || s.lng == null) continue
+          const miles = milesBetween(here, { lat: s.lat, lng: s.lng })
+          if (!best || miles < best.miles) best = { store: s, miles }
+        }
+        if (best) setNearest(best)
+      },
+      () => {},
+      { timeout: 8000, maximumAge: 300000 }
+    )
+  }, [])
+
+  if (!nearest) return null
+
+  const { store, miles } = nearest
+  const status = openNow(store)
+
+  return (
+    <section aria-label='Your nearest Clark’s' className='bg-brand text-white'>
+      <div className='container mx-auto px-6 md:px-10'>
+        <Link
+          to={`/locations/${store.slug}`}
+          className='group flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:justify-between'
+        >
+          <div className='flex flex-wrap items-baseline gap-x-3 gap-y-1'>
+            <span className="font-['Oswald'] text-xs uppercase tracking-wide text-white/70">
+              Your Clark’s
+            </span>
+            <span className="font-['Oswald'] text-lg font-bold md:text-xl">
+              {store.name} · {store.city}, {store.state}
+            </span>
+            <span className='text-sm text-white/85'>
+              {status.label} · {miles.toFixed(1)} mi away
+            </span>
+          </div>
+          <span className='inline-flex shrink-0 items-center gap-1 rounded-xl bg-white px-4 py-2 text-sm font-semibold text-brand transition-transform group-hover:translate-x-0.5'>
+            View store →
+          </span>
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/ClarksPNS/src/pages/About.tsx
+++ b/ClarksPNS/src/pages/About.tsx
@@ -55,6 +55,47 @@ const LEADERSHIP: Person[] = [
   { name: 'Justin Gibson', title: 'Fuel Pricing', img: justinImg }
 ]
 
+// Milestones sourced from the Our Story copy on this page.
+const TIMELINE: Array<{
+  year: string
+  title: string
+  desc: string
+  img?: string
+  imgAlt?: string
+}> = [
+  {
+    year: '1976',
+    title: 'One store in Westwood',
+    desc: 'John W. Clark opens a single convenience store in his hometown of Westwood, Kentucky.',
+    img: westwoodHero,
+    imgAlt: 'The original Clark’s Pump-N-Shop in Westwood, KY'
+  },
+  {
+    year: '1990s',
+    title: 'The next generation',
+    desc: 'With the company grown to 18 locations, John’s three sons — Rick, Rodney, and Brent Clark — purchase the business and keep it in the family.',
+    img: foundersGroup,
+    imgAlt: 'Rick, John W., and Brent Clark at the 29th Street Marathon in Ashland, KY'
+  },
+  {
+    year: '2000s',
+    title: 'Growing across the Tri-State',
+    desc: 'Group acquisitions in central Kentucky and new-store construction expand Clark’s across Kentucky, Ohio, and West Virginia.',
+    img: johnConstruction,
+    imgAlt: 'John W. Clark at the construction of the new store in Jackson, OH'
+  },
+  {
+    year: '2019',
+    title: '63 stores strong',
+    desc: 'Clark’s Pump-N-Shop operates 63 convenience stores in three states, supported by more than 700 team members and a home office in Ashland, KY.'
+  },
+  {
+    year: 'Today',
+    title: 'Still family',
+    desc: 'Owned and operated by Rick and Brent Clark — same family, same promise: Return. Refresh. Refuel.'
+  }
+]
+
 export default function About () {
   return (
     <main className='w-full overflow-x-clip'>
@@ -190,6 +231,59 @@ export default function About () {
               </p>
             </div>
           </div>
+        </div>
+      </section>
+
+      {/* TIMELINE — 50 years, one family */}
+      <section id='timeline' className='py-14 md:py-20 bg-neutral-50 border-y border-black/10'>
+        <div className='container mx-auto px-6 md:px-10'>
+          <div className='max-w-3xl'>
+            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+              Our history
+            </p>
+            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+              Fifty years, one family.
+            </h2>
+          </div>
+
+          <ol className='relative mt-10 space-y-10 border-l-2 border-brand/20 pl-8 md:pl-10'>
+            {TIMELINE.map(t => (
+              <li key={t.year} className='relative'>
+                <span
+                  aria-hidden
+                  className='absolute -left-[41px] top-1 grid h-5 w-5 place-items-center rounded-full border-2 border-brand bg-white md:-left-[49px]'
+                >
+                  <span className='h-2 w-2 rounded-full bg-brand' />
+                </span>
+                <div className='grid grid-cols-1 items-start gap-6 md:grid-cols-12'>
+                  <div className={t.img ? 'md:col-span-7' : 'md:col-span-12'}>
+                    <p className="font-['Oswald'] text-2xl font-bold text-brand leading-none">
+                      {t.year}
+                    </p>
+                    <h3 className="mt-1 font-['Oswald'] text-xl md:text-2xl font-bold text-black">
+                      {t.title}
+                    </h3>
+                    <p className='mt-2 max-w-prose text-black/70'>{t.desc}</p>
+                  </div>
+                  {t.img && (
+                    <figure className='md:col-span-5'>
+                      <img
+                        src={t.img}
+                        alt={t.imgAlt || t.title}
+                        loading='lazy'
+                        className='w-full rounded-2xl border border-black/10 object-cover shadow-sm'
+                      />
+                      {t.imgAlt && (
+                        <figcaption className='mt-2 text-xs text-black/50'>
+                          {t.imgAlt}
+                        </figcaption>
+                      )}
+                    </figure>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
         </div>
       </section>
 

--- a/ClarksPNS/src/pages/BeerCave.tsx
+++ b/ClarksPNS/src/pages/BeerCave.tsx
@@ -1,0 +1,116 @@
+// Beer Cave finder — every Clark's with a walk-in beer cave, from the same
+// amenity data the store pages use.
+import { Link } from 'react-router-dom'
+import { SEO } from '@/lib/seo'
+import { allStores, openNow, type Store } from '@/lib/stores'
+
+const CAVE_STORES = allStores.filter(s => s.amenities?.beerCave)
+
+const BY_STATE: Array<{ state: string; label: string; stores: Store[] }> = [
+  { state: 'KY', label: 'Kentucky' },
+  { state: 'OH', label: 'Ohio' },
+  { state: 'WV', label: 'West Virginia' }
+].map(g => ({
+  ...g,
+  stores: CAVE_STORES.filter(
+    s => (s.state || '').toUpperCase() === g.state
+  ).sort((a, b) => (a.city || '').localeCompare(b.city || ''))
+}))
+
+export default function BeerCave() {
+  return (
+    <main className='w-full overflow-x-clip bg-white'>
+      <SEO
+        title='Beer Cave Finder — Clark’s Pump-N-Shop'
+        description={`Walk-in beer caves at ${CAVE_STORES.length} Clark's Pump-N-Shop locations across Kentucky, Ohio & West Virginia. Ice cold, always stocked.`}
+        path='/beer-cave'
+      />
+
+      {/* Frosty hero */}
+      <section className='relative isolate -mt-[16px] overflow-hidden bg-gradient-to-b from-[#0b1f5e] via-brand to-[#0084FF] md:-mt-[20px]'>
+        {/* frost streaks */}
+        <div
+          aria-hidden
+          className='pointer-events-none absolute inset-0 opacity-[0.12]'
+          style={{
+            background:
+              'repeating-linear-gradient(115deg, #fff 0 1px, transparent 1px 26px)'
+          }}
+        />
+        <div
+          aria-hidden
+          className='pointer-events-none absolute -top-24 left-1/2 h-72 w-[130%] -translate-x-1/2 rounded-[100%] bg-white/10 blur-3xl'
+        />
+        <div className='container relative z-[1] mx-auto px-6 py-20 text-white md:px-10 md:py-28'>
+          <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-white/70">
+            The Beer Cave
+          </div>
+          <h1 className="mt-2 font-['Oswald'] text-5xl font-bold leading-none md:text-7xl">
+            Ice cold.
+            <br />
+            Walk in.
+          </h1>
+          <p className='mt-5 max-w-prose text-lg text-white/85 md:text-xl'>
+            {CAVE_STORES.length} Clark’s locations have a walk-in beer cave —
+            a whole room kept freezing so your six-pack never sees a warm
+            shelf.
+          </p>
+          <a
+            href='#find'
+            className='mt-8 inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 text-base font-semibold text-brand shadow-lg transition-transform hover:-translate-y-0.5 md:text-lg'
+          >
+            Find a cave near you ↓
+          </a>
+        </div>
+        <div className='h-8 w-full bg-gradient-to-b from-transparent to-white md:h-12' />
+      </section>
+
+      {/* Store grid by state */}
+      <section id='find' className='container mx-auto px-6 py-12 md:px-10'>
+        {BY_STATE.filter(g => g.stores.length).map(g => (
+          <div key={g.state} className='mb-10'>
+            <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+              {g.label}
+              <span className='ml-3 align-middle text-base font-normal text-black/50'>
+                {g.stores.length} cave{g.stores.length === 1 ? '' : 's'}
+              </span>
+            </h2>
+            <div className='mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+              {g.stores.map(s => (
+                <CaveCard key={s.slug} store={s} />
+              ))}
+            </div>
+          </div>
+        ))}
+        <p className='text-sm text-black/50'>
+          Please drink responsibly. Valid ID required for all alcohol
+          purchases; beer sales hours follow state and local law.
+        </p>
+      </section>
+    </main>
+  )
+}
+
+function CaveCard({ store }: { store: Store }) {
+  const status = openNow(store)
+  return (
+    <Link
+      to={`/locations/${store.slug}`}
+      className='group rounded-2xl border border-black/10 bg-white p-5 shadow-soft transition-shadow hover:shadow-md'
+    >
+      <div className='flex items-center justify-between gap-3'>
+        <div className="font-['Oswald'] text-lg font-bold text-black group-hover:text-brand">
+          {store.name}
+        </div>
+        <span className='shrink-0 rounded-full bg-[#eaf3ff] px-2.5 py-1 text-xs font-semibold text-brand'>
+          ❄ Beer Cave
+        </span>
+      </div>
+      <div className='mt-1 text-sm text-black/70'>
+        {store.address}, {store.city}, {store.state}
+      </div>
+      <div className='mt-2 text-sm text-black/60'>{status.label}</div>
+      <div className='mt-3 text-sm font-medium text-brand'>View store →</div>
+    </Link>
+  )
+}

--- a/ClarksPNS/src/pages/CarWash.tsx
+++ b/ClarksPNS/src/pages/CarWash.tsx
@@ -47,10 +47,10 @@ export default function CarWash () {
 
                 <div className='flex flex-col sm:flex-row gap-3 sm:gap-4'>
                   <a
-                    href='#packages'
+                    href='#club'
                     className='inline-flex items-center justify-center rounded-2xl px-6 py-3 text-white bg-brand hover:bg-brand/90 transition-all shadow-lg shadow-brand/20 text-base md:text-lg'
                   >
-                    View Packages
+                    Join the Keep It Clean Club
                   </a>
                   <Link
                     to='/locations?amenity=carwash'
@@ -145,39 +145,69 @@ export default function CarWash () {
           </div>
         </div>
       </section>
-      {/* === Benefits ===
-      <section aria-label="Car Wash Benefits" className="py-12 md:py-20 bg-white">
-        <div className="container mx-auto px-6 md:px-10">
-          <div className="max-w-3xl">
+      {/* === Benefits === */}
+      <section aria-label='Car Wash Benefits' className='py-12 md:py-20 bg-white'>
+        <div className='container mx-auto px-6 md:px-10'>
+          <div className='max-w-3xl'>
             <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
               Why wash at Clarks
             </h2>
-            <p className="mt-2 text-black/70 text-base md:text-lg">
+            <p className='mt-2 text-black/70 text-base md:text-lg'>
               Pro formulas, soft-touch materials, and a spotless finish—fast.
             </p>
           </div>
 
-          <div className="mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-            {BENEFITS.map((b) => (
+          <div className='mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6'>
+            {BENEFITS.map(b => (
               <article
                 key={b.title}
-                className="rounded-2xl border border-black/10 p-6 hover:shadow-md transition-shadow bg-white"
+                className='rounded-2xl border border-black/10 p-6 hover:shadow-md transition-shadow bg-white'
               >
-                <div className="mb-4">
+                <div className='mb-4'>
                   <span
                     aria-hidden
-                    className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-brand/10"
+                    className='inline-flex h-12 w-12 items-center justify-center rounded-xl bg-brand/10'
                   >
-                    <b className="text-xl">{b.icon}</b>
+                    <b className='text-xl'>{b.icon}</b>
                   </span>
                 </div>
                 <h3 className="font-['Oswald'] text-xl font-bold text-black">{b.title}</h3>
-                <p className="mt-2 text-black/70 text-sm leading-relaxed">{b.desc}</p>
+                <p className='mt-2 text-black/70 text-sm leading-relaxed'>{b.desc}</p>
               </article>
             ))}
           </div>
         </div>
-      </section> */}
+      </section>
+
+      {/* === How it works === */}
+      <section aria-label='How it works' className='py-12 md:py-20 bg-neutral-50 border-y border-black/10'>
+        <div className='container mx-auto px-6 md:px-10'>
+          <div className='max-w-3xl'>
+            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+              How it works
+            </h2>
+            <p className='mt-2 text-black/70 text-base md:text-lg'>
+              Three steps between you and a showroom shine.
+            </p>
+          </div>
+          <ol className='mt-10 grid grid-cols-1 md:grid-cols-3 gap-6'>
+            {STEPS.map((s, i) => (
+              <li
+                key={s.title}
+                className='relative rounded-2xl border border-black/10 bg-white p-6'
+              >
+                <span className="font-['Oswald'] absolute -top-4 left-6 grid h-9 w-9 place-items-center rounded-xl bg-brand text-lg font-bold text-white shadow-md">
+                  {i + 1}
+                </span>
+                <h3 className="mt-2 font-['Oswald'] text-xl font-bold text-black">
+                  {s.title}
+                </h3>
+                <p className='mt-2 text-sm leading-relaxed text-black/70'>{s.desc}</p>
+              </li>
+            ))}
+          </ol>
+        </div>
+      </section>
 
       
       {/* === Packages / Pricing === */}

--- a/ClarksPNS/src/pages/Home.tsx
+++ b/ClarksPNS/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 // import MobileHero from '@/components/site/MobileHero'
 import { DesktopHero } from '@/components/site/DesktopHero'
+import YourClarks from '@/components/site/YourClarks'
 import { SEO } from '@/lib/seo'
 
 // MobileHero images (keep as-is)
@@ -343,6 +344,9 @@ export default function Home () {
 
       {/* Desktop hero , now contains mobile responsive version as well */}
       <DesktopHero />
+
+      {/* Your nearest Clark's — appears once the visitor shares location */}
+      <YourClarks />
 
       {/* Rewards Phone Animation */}
       <section

--- a/ClarksPNS/src/pages/Home.tsx
+++ b/ClarksPNS/src/pages/Home.tsx
@@ -49,14 +49,22 @@ function MonthlyPromotions ({
   autoPlay?: boolean
 }) {
   const scrollerRef = React.useRef<HTMLDivElement | null>(null)
-  const timerRef = React.useRef<number | null>(null)
+  const rafRef = React.useRef<number | null>(null)
   const userPausedRef = React.useRef(false)
+  // Fractional scroll position — scrollLeft rounds to whole pixels, so we
+  // accumulate sub-pixel movement here and assign from it each frame.
+  const posRef = React.useRef(0)
   const [openSrc, setOpenSrc] = React.useState<string | null>(null)
 
+  // Continuous marquee: the promo list renders twice, and once we scroll
+  // past the first copy we jump back by exactly one copy's width — an
+  // endless, seamless belt of every special. ~35px/s, pauses on hover.
+  const MARQUEE_PX_PER_FRAME = 0.6
+
   const clear = React.useCallback(() => {
-    if (timerRef.current) {
-      window.clearInterval(timerRef.current)
-      timerRef.current = null
+    if (rafRef.current) {
+      cancelAnimationFrame(rafRef.current)
+      rafRef.current = null
     }
   }, [])
 
@@ -64,24 +72,31 @@ function MonthlyPromotions ({
     const el = scrollerRef.current
     if (!el) return
     const amount = Math.min(el.clientWidth * 0.9, 520)
-    const atEnd =
-      Math.round(el.scrollLeft + el.clientWidth) >= el.scrollWidth - 2
-    if (dir === 1 && atEnd) {
-      el.scrollTo({ left: 0, behavior: 'smooth' })
-    } else {
-      el.scrollBy({ left: dir * amount, behavior: 'smooth' })
-    }
+    el.scrollBy({ left: dir * amount, behavior: 'smooth' })
   }, [])
 
   const start = React.useCallback(() => {
-    if (!autoPlay || openSrc) return
+    if (!autoPlay || openSrc || rafRef.current) return
     const reduced =
       window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false
-    if (reduced || timerRef.current) return
-    timerRef.current = window.setInterval(() => {
-      if (!userPausedRef.current) scrollStep(1)
-    }, intervalMs) as unknown as number
-  }, [autoPlay, intervalMs, scrollStep, openSrc])
+    if (reduced) return
+    const tick = () => {
+      const el = scrollerRef.current
+      if (el && !userPausedRef.current) {
+        // resync after any manual scroll (arrows, swipe, trackpad)
+        if (Math.abs(el.scrollLeft - posRef.current) > 2) {
+          posRef.current = el.scrollLeft
+        }
+        const half = el.scrollWidth / 2
+        let next = posRef.current + MARQUEE_PX_PER_FRAME
+        if (half > 0 && next >= half) next -= half
+        posRef.current = next
+        el.scrollLeft = next
+      }
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+  }, [autoPlay, openSrc])
 
   React.useEffect(() => {
     start()
@@ -194,7 +209,7 @@ function MonthlyPromotions ({
             onFocusCapture={onUserEnter}
             onBlurCapture={onUserLeave}
             className='
-            flex gap-4 overflow-x-auto overscroll-x-contain snap-x snap-mandatory
+            flex gap-4 overflow-x-auto overscroll-x-contain
             [scrollbar-width:none] [-ms-overflow-style:none]
             pl-[max(1.5rem,calc((100vw-1280px)/2))]
             pr-[max(1.5rem,calc((100vw-1280px)/2))]
@@ -206,12 +221,14 @@ function MonthlyPromotions ({
           >
             <style>{`.hide-scrollbar::-webkit-scrollbar{display:none}`}</style>
 
-            {images.map(src => (
+            {[...images, ...images].map((src, i) => (
               <button
-                key={src}
+                key={`${src}-${i}`}
                 type='button'
                 onClick={() => setOpenSrc(src)}
-                className='group relative flex-none snap-center hide-scrollbar w-[82%] xs:w-[72%] sm:w-[58%] md:w-1/3'
+                aria-hidden={i >= images.length || undefined}
+                tabIndex={i >= images.length ? -1 : undefined}
+                className='group relative flex-none hide-scrollbar w-[82%] xs:w-[72%] sm:w-[58%] md:w-1/3'
                 title='Open promotion'
                 aria-label='Open promotion'
               >


### PR DESCRIPTION
Five additions, all reviewed locally by Seth:

- **Your Clark's** homepage band — visitor's nearest store with live open/closed status and mileage (appears only when location is shared)
- **/beer-cave** — frosty finder page for all 47 stores with walk-in beer caves, grouped by state
- **Car Wash** — benefits grid enabled, 3-step How It Works added, hero CTA fixed (was pointing at a removed #packages anchor)
- **About** — 'Fifty years, one family' timeline (1976 Westwood → today) using the historic photos already in the repo
- **Monthly Specials** — continuous seamless marquee of all promos (pauses on hover, respects prefers-reduced-motion)

tsc + vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)