### PR TITLE
The elevation: brand system, live ticker, beacon map, new pages, features

### DIFF
--- a/ClarksPNS/ATLAS-INTEGRATION.md
+++ b/ClarksPNS/ATLAS-INTEGRATION.md
@@ -1,0 +1,86 @@
+# ATLAS Integration Guide — Clark's Pump-N-Shop site
+
+How the ATLAS agency OS can read from and operate this site. Everything
+below is live in production (myclarkspns.com) once deployed.
+
+## Repository
+
+- GitHub: `Boyle-Digital/ClarksPNS` (app lives in the `ClarksPNS/` subdirectory)
+- Deploys: push to `main` -> Vercel builds and ships production automatically
+- Local working clone: `~/Downloads/ClarksPNS`
+
+## 1. Sitewide notice banner (operable from ATLAS)
+
+`ClarksPNS/public/notice.json` controls a banner shown under the live
+ticker on every page:
+
+```json
+{
+  "active": true,
+  "message": "Route 5 store closed for repaving until Friday.",
+  "link": "/locations/route-5-store-slug",
+  "linkLabel": "Details",
+  "tone": "info"
+}
+```
+
+- `tone`: `"info"` (Medium Blue) or `"alert"` (red)
+- Flip via the GitHub Contents API (commit to `main`; Vercel redeploys):
+  `PUT /repos/Boyle-Digital/ClarksPNS/contents/ClarksPNS/public/notice.json`
+- The banner is fetched with `cache: no-store`, so it takes effect on the
+  next page load after deploy.
+
+## 2. Data files (source of truth)
+
+| File | What it is |
+| --- | --- |
+| `ClarksPNS/src/assets/data/stores.geocoded.json` | Raw store data (names, addresses, hours, amenities, lat/lng). Edit here first. |
+| `ClarksPNS/src/content/stores.index.json` | Generated index used by the site. Regenerate with `pnpm stores` after editing the raw file. |
+| `ClarksPNS/src/content/store-media.json` | Cloudinary URLs per store (hero, video, poster, gallery, thumbs). |
+| `ClarksPNS/src/content/menus.ts` | Typed kitchen menus (transcribed from printed boards). |
+| `ClarksPNS/public/sitemap.xml` | Generated with `pnpm stores` (81 URLs). |
+
+## 3. Media pipeline (Cloudinary)
+
+- Cloud name `yzpytwu5`; all assets under `clarks/stores/<slug>/...`
+- Delivery pattern:
+  `https://res.cloudinary.com/yzpytwu5/image/upload/f_auto,q_auto/v1/clarks/stores/<slug>/hero.jpg`
+- Videos: `/video/upload/w_1280,q_auto:eco/v1/clarks/stores/<slug>/drone.mp4`
+- Share cards are composed on the fly (see `ogImageUrl` in
+  `src/lib/stores.ts`) — no pre-rendering needed.
+- Upload credentials: local env file at
+  `~/Downloads/clarks-store-pages/.cloudinary.env` (never committed).
+- Master local media: `~/Downloads/clarks-media-web/<slug>/`.
+
+## 4. Conversion events (Vercel Analytics)
+
+Custom events ATLAS can report on from the Vercel dashboard/API:
+
+| Event | Fired when | Props |
+| --- | --- | --- |
+| `directions_click` | Get Directions on a store page | `store` |
+| `call_click` | Tap-to-call on a store page | `store` |
+| `rewards_join_click` | Join button on Rewards hero | `placement` |
+| `fleet_card_click` | Marathon fleet card CTA | `placement` |
+| `road_trip` | Road Trip search on Locations | `from`, `to`, `found` |
+
+## 5. Live behavior with no backend
+
+- Ticker + open/closed states compute client-side from store hours.
+- Weather touches (Car Wash wash-window, kerosene cold-snap notes) call
+  Open-Meteo directly — free, keyless, fails silently.
+- Search, Beacon Map, Road Trip are all client-side over the store index.
+
+## 6. Standing content rules
+
+- No fuel prices anywhere until Clark's provides a real pricing feed
+  (ticker items have a reserved `price` slot).
+- No emojis in UI; icons come from `src/components/site/Icons.tsx`.
+- Display face: Bebas Neue (`font-display`); body: Inter.
+- Anniversary/year-count claims are off-limits per client.
+
+## Open items awaiting Clark's
+
+Wash-location list, dog-park stores, flagship store number, GBP manager
+access (Website deep-links + reviews), app store links, fleet rate table,
+food codes GG/IC.

--- a/ClarksPNS/package.json
+++ b/ClarksPNS/package.json
@@ -23,12 +23,17 @@
     "stores": "node scripts/build-stores.mjs"
   },
   "dependencies": {
+    "@fontsource/inter": "^5.2.8",
     "@fontsource/oswald": "^5.2.6",
     "@googlemaps/markerclusterer": "^2.6.2",
     "@react-google-maps/api": "^2.20.7",
+    "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "clsx": "^2.1.1",
+    "html-to-image": "^1.11.13",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^3.0.0",
     "react-router-dom": "^7.8.1"
   },
   "devDependencies": {

--- a/ClarksPNS/package.json
+++ b/ClarksPNS/package.json
@@ -23,6 +23,7 @@
     "stores": "node scripts/build-stores.mjs"
   },
   "dependencies": {
+    "@fontsource/bebas-neue": "^5.2.7",
     "@fontsource/inter": "^5.2.8",
     "@fontsource/oswald": "^5.2.6",
     "@googlemaps/markerclusterer": "^2.6.2",

--- a/ClarksPNS/pnpm-lock.yaml
+++ b/ClarksPNS/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/bebas-neue':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@fontsource/inter':
         specifier: ^5.2.8
         version: 5.2.8
@@ -400,6 +403,9 @@ packages:
   '@eslint/plugin-kit@0.4.0':
     resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fontsource/bebas-neue@5.2.7':
+    resolution: {integrity: sha512-DsmBrmq55d9BCU0mt4DT4RZDdH8vhWRKEUOfbuNB1EEjMuwbtFvM8N+3gIlkYSFbsb10P8Q19BV5OdpMu2h0fA==}
 
   '@fontsource/inter@5.2.8':
     resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
@@ -2237,6 +2243,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.16.0
       levn: 0.4.1
+
+  '@fontsource/bebas-neue@5.2.7': {}
 
   '@fontsource/inter@5.2.8': {}
 

--- a/ClarksPNS/pnpm-lock.yaml
+++ b/ClarksPNS/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/inter':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@fontsource/oswald':
         specifier: ^5.2.6
         version: 5.2.8
@@ -17,15 +20,27 @@ importers:
       '@react-google-maps/api':
         specifier: ^2.20.7
         version: 2.20.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@vercel/analytics':
+        specifier: ^2.0.1
+        version: 2.0.1(react@18.3.1)
+      '@vercel/speed-insights':
+        specifier: ^2.0.0
+        version: 2.0.0(react@18.3.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       react:
         specifier: ^18.3.1
         version: 18.3.1
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-helmet-async:
+        specifier: ^3.0.0
+        version: 3.0.0(react@18.3.1)
       react-router-dom:
         specifier: ^7.8.1
         version: 7.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -385,6 +400,9 @@ packages:
   '@eslint/plugin-kit@0.4.0':
     resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fontsource/inter@5.2.8':
+    resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
 
   '@fontsource/oswald@5.2.8':
     resolution: {integrity: sha512-DFoPK1BqsFIQhVjs2xgO/oL9veF9oUJgFojEWIU+nazUrfqsBDtAMI4n9L9CZFX3kQNDLcCyzKx1xoEDvQT4WQ==}
@@ -881,6 +899,61 @@ packages:
     resolution: {integrity: sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vercel/analytics@2.0.1':
+    resolution: {integrity: sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==}
+    peerDependencies:
+      '@remix-run/react': ^2
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@remix-run/react':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@2.0.0':
+    resolution: {integrity: sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      nuxt: '>= 3'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
   '@vitejs/plugin-react@5.0.4':
     resolution: {integrity: sha512-La0KD0vGkVkSk6K+piWDKRUyg8Rl5iAIKRMH0vMJI0Eg47bq1eOxmoObAaQG37WMW9MSyk7Cs8EIWwJC1PtzKA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1288,6 +1361,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1615,6 +1691,14 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
+  react-helmet-async@3.0.0:
+    resolution: {integrity: sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==}
+    peerDependencies:
+      react: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -1685,6 +1769,9 @@ packages:
 
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+
+  shallowequal@1.1.0:
+    resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
   sharp@0.34.4:
     resolution: {integrity: sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==}
@@ -2151,6 +2238,8 @@ snapshots:
       '@eslint/core': 0.16.0
       levn: 0.4.1
 
+  '@fontsource/inter@5.2.8': {}
+
   '@fontsource/oswald@5.2.8': {}
 
   '@googlemaps/js-api-loader@1.16.8': {}
@@ -2614,6 +2703,14 @@ snapshots:
       '@typescript-eslint/types': 8.45.0
       eslint-visitor-keys: 4.2.1
 
+  '@vercel/analytics@2.0.1(react@18.3.1)':
+    optionalDependencies:
+      react: 18.3.1
+
+  '@vercel/speed-insights@2.0.0(react@18.3.1)':
+    optionalDependencies:
+      react: 18.3.1
+
   '@vitejs/plugin-react@5.0.4(vite@7.1.9(@types/node@24.7.0)(jiti@1.21.7))':
     dependencies:
       '@babel/core': 7.28.4
@@ -3037,6 +3134,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-to-image@1.11.13: {}
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3301,6 +3400,15 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-fast-compare@3.2.2: {}
+
+  react-helmet-async@3.0.0(react@18.3.1):
+    dependencies:
+      invariant: 2.2.4
+      react: 18.3.1
+      react-fast-compare: 3.2.2
+      shallowequal: 1.1.0
+
   react-refresh@0.17.0: {}
 
   react-router-dom@7.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -3382,6 +3490,8 @@ snapshots:
   semver@7.7.2: {}
 
   set-cookie-parser@2.7.1: {}
+
+  shallowequal@1.1.0: {}
 
   sharp@0.34.4:
     dependencies:

--- a/ClarksPNS/public/notice.json
+++ b/ClarksPNS/public/notice.json
@@ -1,0 +1,7 @@
+{
+  "active": false,
+  "message": "",
+  "link": "",
+  "linkLabel": "",
+  "tone": "info"
+}

--- a/ClarksPNS/public/sitemap.xml
+++ b/ClarksPNS/public/sitemap.xml
@@ -10,6 +10,10 @@
   <url><loc>https://www.myclarkspns.com/clarks-rewards</loc><changefreq>monthly</changefreq></url>
   <url><loc>https://www.myclarkspns.com/car-wash</loc><changefreq>monthly</changefreq></url>
   <url><loc>https://www.myclarkspns.com/locations</loc><changefreq>daily</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/beer-cave</loc><changefreq>monthly</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/community</loc><changefreq>monthly</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/scholarship</loc><changefreq>monthly</changefreq></url>
+  <url><loc>https://www.myclarkspns.com/fleet</loc><changefreq>monthly</changefreq></url>
   <url><loc>https://www.myclarkspns.com/about-us</loc><changefreq>monthly</changefreq></url>
   <url><loc>https://www.myclarkspns.com/careers</loc><changefreq>weekly</changefreq></url>
   <url><loc>https://www.myclarkspns.com/locations/westwood-ashland-ky</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>

--- a/ClarksPNS/scripts/build-stores.mjs
+++ b/ClarksPNS/scripts/build-stores.mjs
@@ -131,6 +131,10 @@ const staticUrls = [
   { loc: '/clarks-rewards', changefreq: 'monthly' },
   { loc: '/car-wash', changefreq: 'monthly' },
   { loc: '/locations', changefreq: 'daily' },
+  { loc: '/beer-cave', changefreq: 'monthly' },
+  { loc: '/community', changefreq: 'monthly' },
+  { loc: '/scholarship', changefreq: 'monthly' },
+  { loc: '/fleet', changefreq: 'monthly' },
   { loc: '/about-us', changefreq: 'monthly' },
   { loc: '/careers', changefreq: 'weekly' }
 ]

--- a/ClarksPNS/src/App.tsx
+++ b/ClarksPNS/src/App.tsx
@@ -16,6 +16,7 @@ import FoodBrand from '@/pages/FoodBrand'
 import BeerCave from '@/pages/BeerCave'
 import Community from '@/pages/Community'
 import Scholarship from '@/pages/Scholarship'
+import Fleet from '@/pages/Fleet'
 import Careers from '@/pages/Careers'
 import Terms from '@/pages/Terms'
 import Privacy from '@/pages/Privacy'
@@ -48,6 +49,7 @@ export default function App () {
           <Route path='/beer-cave' element={<BeerCave />} />
           <Route path='/community' element={<Community />} />
           <Route path='/scholarship' element={<Scholarship />} />
+          <Route path='/fleet' element={<Fleet />} />
           <Route path='/Careers' element={<Careers />} />
           <Route path='/terms' element={<Terms />} />
           <Route path='/privacy' element={<Privacy />} />

--- a/ClarksPNS/src/App.tsx
+++ b/ClarksPNS/src/App.tsx
@@ -14,10 +14,11 @@ import Locations from '@/pages/Locations'
 import StoreDetail from '@/pages/StoreDetail'
 import FoodBrand from '@/pages/FoodBrand'
 import BeerCave from '@/pages/BeerCave'
+import Community from '@/pages/Community'
+import Scholarship from '@/pages/Scholarship'
 import Careers from '@/pages/Careers'
 import Terms from '@/pages/Terms'
 import Privacy from '@/pages/Privacy'
-import MenuTest from '@/pages/menuTest'
 import NotFound from '@/pages/NotFound'
 
 import { SpeedInsights } from '@vercel/speed-insights/react'
@@ -45,11 +46,12 @@ export default function App () {
           <Route path='/Food' element={<Food />} />
           <Route path='/food/:slug' element={<FoodBrand />} />
           <Route path='/beer-cave' element={<BeerCave />} />
+          <Route path='/community' element={<Community />} />
+          <Route path='/scholarship' element={<Scholarship />} />
           <Route path='/Careers' element={<Careers />} />
           <Route path='/terms' element={<Terms />} />
           <Route path='/privacy' element={<Privacy />} />
           {/* <Route path='/Sponsorship' element={<Sponsorship />} /> */}
-          <Route path='/menuTest' element={<MenuTest />} />
           <Route path='*' element={<NotFound />} />
         </Routes>
         <Footer />

--- a/ClarksPNS/src/components/Footer.tsx
+++ b/ClarksPNS/src/components/Footer.tsx
@@ -1,181 +1,177 @@
-import React from 'react'
+// Footer — night-mode rebuild. Ghost wordmark, four link columns,
+// Tri-State pride line, socials, and the fine print.
+import { Link } from 'react-router-dom'
 
-// SVG imports via Vite + SVGR
 import FacebookIcon from '@/assets/icons/facebook.svg?react'
 import InstagramIcon from '@/assets/icons/instagram.svg?react'
 import TikTokIcon from '@/assets/icons/tiktok.svg?react'
 import YouTubeIcon from '@/assets/icons/youtube.svg?react'
 import logoWhite from '@/assets/images/Clarks PNS Logo Updated all white.png'
 
-type NavLink = { label: string; href: string }
-
-const defaultNav: NavLink[] = [
-  { label: 'Home', href: '/' },
-  { label: 'Clarks Rewards', href: '/clarks-rewards' },
-  { label: 'Locations', href: '/locations' },
-  { label: 'Car Wash', href: '/car-wash' },
-  { label: 'Food', href: '/food' },
-  { label: 'Careers', href: '/careers' },
-  { label: 'Our Story', href: '/about-us' },
-  { label: 'Clarks Charity', href: '/charity' },
-  { label: 'Sponsorship', href: '/sponsorship' }
+const COLUMNS: Array<{ title: string; links: Array<{ label: string; href: string }> }> = [
+  {
+    title: 'Find us',
+    links: [
+      { label: 'All locations', href: '/locations' },
+      { label: 'Beer Cave finder', href: '/beer-cave' },
+      { label: 'Fleet & diesel', href: '/fleet' },
+      { label: 'Car wash', href: '/car-wash' }
+    ]
+  },
+  {
+    title: 'Food',
+    links: [
+      { label: 'All kitchens', href: '/food' },
+      { label: 'Krispy Krunchy', href: '/food/krispy-krunchy' },
+      { label: 'Hangar 54 Pizza', href: '/food/hangar-54' },
+      { label: 'Clark’s Café', href: '/food/clarks-cafe' }
+    ]
+  },
+  {
+    title: 'Rewards',
+    links: [
+      { label: 'Clarks Rewards', href: '/clarks-rewards' },
+      { label: 'Keep It Clean Club', href: '/car-wash#club' },
+      { label: 'Gift cards', href: '/car-wash#giftcards' },
+      {
+        label: 'Fleet card',
+        href: 'https://www.marathonfleetcard.com/associations/?cc=M00528'
+      }
+    ]
+  },
+  {
+    title: 'Community',
+    links: [
+      { label: 'Our story', href: '/about-us' },
+      { label: 'Sports & community', href: '/community' },
+      { label: 'Scholarships', href: '/scholarship' },
+      { label: 'Charity', href: '/charity' },
+      { label: 'Careers', href: '/careers' }
+    ]
+  }
 ]
 
-interface FooterProps {
-  nav?: NavLink[]
-  year?: number
-}
-// test
-const Footer: React.FC<FooterProps> = ({
-  nav = defaultNav,
-  year = new Date().getFullYear()
-}) => {
-  return (
-    <footer id='footer-contact' className='bg-brand text-text-onBrand'>
-      {/* Top sections */}
-      <div className='container max-w-screen-2xl'>
-        <div className='grid grid-cols-1 md:grid-cols-12 divide-y md:divide-y-0 md:divide-x divide-text-onBrand/20'>
-          {/* INFO & LOCATION */}
-          <section className='py-8 md:py-12 md:col-span-6 md:pr-12 text-left'>
-            <div className='flex items-center gap-4 mb-4 -ml-0'>
-              <img
-                src={logoWhite}
-                alt="Clark's Pump-N-Shop logo"
-                className='h-8 w-auto'
-              />
-              <h3 className='text-h3 font-bold tracking-wide'>
-                INFO &amp; LOCATION
-              </h3>
-            </div>
+const SOCIALS = [
+  { Icon: TikTokIcon, label: 'TikTok', href: 'https://www.tiktok.com/@clarkspns' },
+  { Icon: InstagramIcon, label: 'Instagram', href: 'https://www.instagram.com/clarkspns' },
+  { Icon: YouTubeIcon, label: 'YouTube', href: 'https://www.youtube.com/@clarkspns' },
+  { Icon: FacebookIcon, label: 'Facebook', href: 'https://www.facebook.com/clarkspns' }
+]
 
-            <address className='not-italic space-y-2 text-text-onBrand/90 leading-relaxed'>
+export default function Footer({ year = new Date().getFullYear() }: { year?: number }) {
+  return (
+    <footer id='footer-contact' className='band-night brand-stripes relative overflow-hidden text-white'>
+      <div aria-hidden className='ghost-word ghost-word--light text-center'>
+        CLARK’S
+      </div>
+
+      <div className='container relative mx-auto px-6 pt-14 md:px-10 md:pt-20'>
+        {/* Top: logo + promise */}
+        <div className='flex flex-col items-start justify-between gap-6 border-b border-white/10 pb-10 md:flex-row md:items-end'>
+          <div>
+            <img src={logoWhite} alt="Clark's Pump-N-Shop" className='h-12 w-auto md:h-14' />
+            <p className='mt-4 font-display text-3xl leading-none md:text-4xl'>
+              Return. Refresh. Refuel.
+            </p>
+            <p className='mt-2 text-white/70'>
+              Family owned since 1976 — at home across Kentucky, Ohio &
+              West Virginia.
+            </p>
+          </div>
+          <div className='flex items-center gap-5'>
+            {SOCIALS.map(({ Icon, label, href }) => (
+              <a
+                key={label}
+                href={href}
+                aria-label={label}
+                target='_blank'
+                rel='noreferrer'
+                className='grid h-11 w-11 place-items-center rounded-xl border border-white/15 bg-white/5 transition-colors hover:border-white/40 hover:bg-white/10 [&_*]:fill-current [&_*]:stroke-current'
+              >
+                <Icon className='h-5 w-5' />
+              </a>
+            ))}
+          </div>
+        </div>
+
+        {/* Link columns + office */}
+        <div className='grid grid-cols-2 gap-10 py-10 md:grid-cols-5'>
+          {COLUMNS.map(col => (
+            <nav key={col.title} aria-label={col.title}>
+              <h3 className='font-display text-lg tracking-[0.08em] text-white'>
+                {col.title.toUpperCase()}
+              </h3>
+              <ul className='mt-3 space-y-2 text-sm text-white/70'>
+                {col.links.map(l => (
+                  <li key={l.href}>
+                    {l.href.startsWith('http') ? (
+                      <a href={l.href} target='_blank' rel='noreferrer' className='transition-colors hover:text-white'>
+                        {l.label}
+                      </a>
+                    ) : (
+                      <Link to={l.href} className='transition-colors hover:text-white'>
+                        {l.label}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ))}
+
+          <address className='col-span-2 not-italic md:col-span-1'>
+            <h3 className='font-display text-lg tracking-[0.08em] text-white'>
+              HOME OFFICE
+            </h3>
+            <div className='mt-3 space-y-2 text-sm text-white/70'>
               <p>
-                <span className='font-semibold'>Home Office:</span> 101 Wheatley
-                Rd, Ashland, KY 41101, United States
+                101 Wheatley Rd
+                <br />
+                Ashland, KY 41101
               </p>
               <p>
-                <span className='font-semibold'>Phone:</span>{' '}
-                <a
-                  className='underline underline-offset-4 hover:text-text-onBrand'
-                  href='tel:16063272775'
-                >
+                <a href='tel:16063272775' className='transition-colors hover:text-white'>
                   606-327-2775
                 </a>
               </p>
               <p>
-                <span className='font-semibold'>Email:</span>{' '}
-                <a
-                  className='underline underline-offset-4 hover:text-text-onBrand'
-                  href='mailto:contactus@clarkspns.com'
-                >
+                <a href='mailto:contactus@clarkspns.com' className='transition-colors hover:text-white'>
                   contactus@clarkspns.com
                 </a>
               </p>
-              <p>
-                <span className='font-semibold'>Office Hours:</span> Mon–Fri 8am
-                – 5pm
-              </p>
-            </address>
-          </section>
-
-          {/* NAV LINKS */}
-          <nav className='py-8 md:py-12 md:col-span-6 md:pl-12 text-left'>
-            <h3 className='text-h3 font-bold tracking-wide mb-4'>Navigation</h3>
-            <ul className='grid grid-cols-2 sm:grid-cols-3 gap-y-2 gap-x-6 text-text-onBrand/90'>
-              {nav.map(item => (
-                <li key={item.href}>
-                  <a
-                    href={item.href}
-                    className='hover:text-text-onBrand transition-colors'
-                  >
-                    {item.label}
-                  </a>
-                </li>
-              ))}
-            </ul>
-          </nav>
+              <p>Mon–Fri 8am–5pm</p>
+            </div>
+          </address>
         </div>
       </div>
 
-      {/* Divider */}
-      <div className='border-t border-text-onBrand/10' />
-
       {/* Bottom bar */}
-      <div className='container max-w-screen-2xl'>
-        <div className='flex flex-col md:flex-row items-center justify-between gap-4 py-6'>
-          {/* Socials */}
-          <div className='flex items-center gap-6'>
+      <div className='relative border-t border-white/10 bg-[#0b153a]/60'>
+        <div className='container mx-auto flex flex-col items-center justify-between gap-3 px-6 py-5 text-xs text-white/60 md:flex-row md:px-10'>
+          <p className='font-display text-sm tracking-[0.25em] text-white/50'>
+            KY · OH · WV
+          </p>
+          <p className='text-center md:text-right'>
+            © {year} Clark’s Pump-N-Shop. All rights reserved ·{' '}
+            <a href='/terms' className='underline transition-colors hover:text-white'>
+              Terms
+            </a>{' '}
+            ·{' '}
+            <a href='/privacy' className='underline transition-colors hover:text-white'>
+              Privacy
+            </a>{' '}
+            · Website by{' '}
             <a
-              href='https://www.tiktok.com/@clarkspns'
-              aria-label='TikTok'
+              href='https://www.boyledigital.com'
               target='_blank'
-              rel='noreferrer'
-              className='group opacity-90 hover:opacity-100 transition-opacity [&_*]:fill-current [&_*]:stroke-current'
+              rel='noopener noreferrer'
+              className='underline transition-colors hover:text-white'
             >
-              <TikTokIcon className='h-6 w-6' />
+              Boyle Digital
             </a>
-            <a
-              href='https://www.instagram.com/clarkspns'
-              aria-label='Instagram'
-              target='_blank'
-              rel='noreferrer'
-              className='group opacity-90 hover:opacity-100 transition-opacity [&_*]:fill-current [&_*]:stroke-current'
-            >
-              <InstagramIcon className='h-6 w-6' />
-            </a>
-            <a
-              href='https://www.youtube.com/@clarkspns'
-              aria-label='YouTube'
-              target='_blank'
-              rel='noreferrer'
-              className='group opacity-90 hover:opacity-100 transition-opacity [&_*]:fill-current [&_*]:stroke-current'
-            >
-              <YouTubeIcon className='h-6 w-6' />
-            </a>
-            <a
-              href='https://www.facebook.com/clarkspns'
-              aria-label='Facebook'
-              target='_blank'
-              rel='noreferrer'
-              className='group opacity-90 hover:opacity-100 transition-opacity [&_*]:fill-current [&_*]:stroke-current'
-            >
-              <FacebookIcon className='h-6 w-6' />
-            </a>
-          </div>
-
-         <p className='text-[14px] text-text-onBrand/80 text-center md:text-right'>
-  © {year} Clark's Pump-N-Shop. All rights reserved {' | '}
-  <a
-    href="/terms"
-    target="_blank"
-    rel="noopener noreferrer"
-    className="underline hover:text-text-onBrand transition-colors"
-  >
-    Terms & Conditions
-  </a>
-{' | '}
-<a
-  href="/privacy"
-  target="_blank"
-  rel="noopener noreferrer"
-  className="underline hover:text-text-onBrand transition-colors"
->
-  Privacy Policy
-</a>
-  {' | '}Website by{' '}
-  <a
-    href="https://www.boyledigital.com"
-    target="_blank"
-    rel="noopener noreferrer"
-    className="underline hover:text-text-onBrand transition-colors"
-  >
-    Boyle Digital
-  </a>
-</p>         
+          </p>
         </div>
       </div>
     </footer>
   )
 }
-
-export default Footer

--- a/ClarksPNS/src/components/site/BeaconMap.tsx
+++ b/ClarksPNS/src/components/site/BeaconMap.tsx
@@ -1,0 +1,161 @@
+// The Beacon Map — every store plotted at its REAL coordinates on a
+// canvas nightscape. Beacons pulse (green open / red closed from live
+// hours), hover names the store, click goes to its page.
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { allStores, openNow, type Store } from '@/lib/stores'
+
+type Plot = { store: Store; x: number; y: number; open: boolean; ph: number }
+
+export default function BeaconMap() {
+  const wrapRef = useRef<HTMLDivElement | null>(null)
+  const cvRef = useRef<HTMLCanvasElement | null>(null)
+  const plotsRef = useRef<Plot[]>([])
+  const [hover, setHover] = useState<Plot | null>(null)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const cv = cvRef.current
+    const wrap = wrapRef.current
+    if (!cv || !wrap) return
+    const ctx = cv.getContext('2d')
+    if (!ctx) return
+
+    const stores = allStores.filter(
+      s => s.lat != null && s.lng != null
+    ) as Array<Store & { lat: number; lng: number }>
+
+    let W = 0
+    let H = 0
+    const dpr = window.devicePixelRatio || 1
+
+    const layout = () => {
+      const r = wrap.getBoundingClientRect()
+      W = cv.width = r.width * dpr
+      H = cv.height = 420 * dpr
+      cv.style.height = '420px'
+      const lats = stores.map(s => s.lat)
+      const lngs = stores.map(s => s.lng)
+      const minLat = Math.min(...lats)
+      const maxLat = Math.max(...lats)
+      const minLng = Math.min(...lngs)
+      const maxLng = Math.max(...lngs)
+      const pad = 0.08
+      plotsRef.current = stores.map((s, i) => ({
+        store: s,
+        x:
+          ((s.lng - minLng) / (maxLng - minLng)) * W * (1 - 2 * pad) + W * pad,
+        y:
+          ((maxLat - s.lat) / (maxLat - minLat)) * H * (1 - 2 * pad) + H * pad,
+        open: openNow(s).open !== false,
+        ph: (i * 0.61) % (Math.PI * 2)
+      }))
+    }
+    layout()
+    window.addEventListener('resize', layout)
+
+    const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches
+    let raf = 0
+    const draw = (t: number) => {
+      ctx.clearRect(0, 0, W, H)
+      // faint highway web: connect each beacon to its nearest neighbor
+      ctx.strokeStyle = 'rgba(0,132,255,0.14)'
+      ctx.lineWidth = 1 * dpr
+      const ps = plotsRef.current
+      for (const p of ps) {
+        let best: Plot | null = null
+        let bd = Infinity
+        for (const q of ps) {
+          if (q === p) continue
+          const d = (q.x - p.x) ** 2 + (q.y - p.y) ** 2
+          if (d < bd) {
+            bd = d
+            best = q
+          }
+        }
+        if (best) {
+          ctx.beginPath()
+          ctx.moveTo(p.x, p.y)
+          ctx.lineTo(best.x, best.y)
+          ctx.stroke()
+        }
+      }
+      // beacons
+      for (const p of ps) {
+        const pulse = reduced ? 0.8 : 0.55 + 0.45 * Math.sin(t / 800 + p.ph)
+        const col = p.open ? '47,208,111' : '255,77,77'
+        const g = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, 14 * dpr)
+        g.addColorStop(0, `rgba(${col},${0.5 * pulse})`)
+        g.addColorStop(1, `rgba(${col},0)`)
+        ctx.fillStyle = g
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, 14 * dpr, 0, 7)
+        ctx.fill()
+        ctx.fillStyle = `rgba(${col},1)`
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, 3 * dpr, 0, 7)
+        ctx.fill()
+      }
+      if (!reduced) raf = requestAnimationFrame(draw)
+    }
+    if (reduced) draw(0)
+    else raf = requestAnimationFrame(draw)
+
+    return () => {
+      cancelAnimationFrame(raf)
+      window.removeEventListener('resize', layout)
+    }
+  }, [])
+
+  const locate = (e: React.MouseEvent): Plot | null => {
+    const cv = cvRef.current
+    if (!cv) return null
+    const r = cv.getBoundingClientRect()
+    const dpr = window.devicePixelRatio || 1
+    const mx = (e.clientX - r.left) * dpr
+    const my = (e.clientY - r.top) * dpr
+    let best: Plot | null = null
+    let bd = Infinity
+    for (const p of plotsRef.current) {
+      const d = (p.x - mx) ** 2 + (p.y - my) ** 2
+      if (d < bd) {
+        bd = d
+        best = p
+      }
+    }
+    return best && bd < (16 * dpr) ** 2 ? best : null
+  }
+
+  return (
+    <div ref={wrapRef} className='relative'>
+      <canvas
+        ref={cvRef}
+        className='block w-full cursor-pointer rounded-2xl border border-white/15'
+        onMouseMove={e => setHover(locate(e))}
+        onMouseLeave={() => setHover(null)}
+        onClick={e => {
+          const p = locate(e)
+          if (p) navigate(`/locations/${p.store.slug}`)
+        }}
+        aria-label='Map of every Clark’s location — click a beacon to open its store page'
+      />
+      {hover && (
+        <div className='pointer-events-none absolute left-1/2 top-3 -translate-x-1/2 rounded-xl bg-[#0b153a] px-4 py-2 text-center shadow-lg ring-1 ring-white/20'>
+          <div className='font-display text-lg leading-none text-white'>
+            {hover.store.name}
+          </div>
+          <div className='text-xs text-white/70'>
+            {hover.store.city}, {(hover.store.state || '').toUpperCase()} ·{' '}
+            <span className={hover.open ? 'text-[#8be3ae]' : 'text-[#ff8a8a]'}>
+              {hover.open ? 'OPEN' : 'CLOSED'}
+            </span>
+          </div>
+        </div>
+      )}
+      <div className='mt-2 text-center text-xs text-white/50'>
+        Every beacon is a real Clark’s at its exact coordinates — green is
+        open right now. Click one to visit the store.
+      </div>
+    </div>
+  )
+}

--- a/ClarksPNS/src/components/site/ColdSnapNote.tsx
+++ b/ClarksPNS/src/components/site/ColdSnapNote.tsx
@@ -1,0 +1,31 @@
+// Cold-snap kerosene note — only renders on stores that actually carry
+// kerosene, and only when the 3-day forecast at that store's coordinates
+// dips below freezing. Weather from Open-Meteo (free, no key).
+import { useEffect, useState } from 'react'
+import type { Store } from '@/lib/stores'
+
+export default function ColdSnapNote({ store }: { store: Store }) {
+  const [cold, setCold] = useState(false)
+
+  useEffect(() => {
+    if (store.lat == null || store.lng == null) return
+    const url =
+      `https://api.open-meteo.com/v1/forecast?latitude=${store.lat}&longitude=${store.lng}` +
+      `&daily=temperature_2m_min&temperature_unit=fahrenheit&forecast_days=3&timezone=auto`
+    fetch(url)
+      .then(r => r.json())
+      .then(d => {
+        const mins: number[] = d?.daily?.temperature_2m_min || []
+        if (mins.some(m => m <= 32)) setCold(true)
+      })
+      .catch(() => {})
+  }, [store.lat, store.lng])
+
+  if (!cold) return null
+
+  return (
+    <p className='mt-3 text-sm text-black/70'>
+      Freezing temperatures in the forecast — this store carries kerosene.
+    </p>
+  )
+}

--- a/ClarksPNS/src/components/site/DesktopHero.tsx
+++ b/ClarksPNS/src/components/site/DesktopHero.tsx
@@ -1,6 +1,7 @@
 // src/components/site/DesktopHero.tsx
 import React from 'react'
 import bgVideo from '@/assets/videos/clarkssecret_1080.mp4'
+import heroLogo from '@/assets/images/Clarks PNS Logo Updated all white.png'
 
 export function DesktopHero () {
   return (
@@ -36,29 +37,31 @@ block   /* <-- was "hidden md:block"; now renders on mobile too */
       <div className='relative z-[1] h-full flex items-center'>
         <div className='container max-w-screen-2xl px-6 md:px-10'>
           <div className='inline-flex flex-col gap-6 md:gap-8 w-full max-w-[720px]'>
+            {/* The brand itself is the hero */}
+            <img
+              src={heroLogo}
+              alt="Clark's Pump-N-Shop — Return. Refresh. Refuel."
+              className='w-[290px] sm:w-[380px] md:w-[520px] h-auto drop-shadow-[0_6px_28px_rgba(0,0,0,0.45)]'
+            />
+
             <h1
               className="
-font-display font-extrabold text-white leading-[1.03]
-text-4xl sm:text-5xl md:text-7xl xl:text-8xl tracking-tight
-drop-shadow-[0_2px_18px_rgba(0,0,0,0.35)]
+font-display text-white leading-none
+text-4xl sm:text-5xl md:text-7xl
+drop-shadow-[0_2px_18px_rgba(0,0,0,0.4)]
 "
             >
-              Return.
-              <br />
-              Refresh.
-              <br />
-              Refuel.
+              Return. Refresh. Refuel.
             </h1>
 
-            {/* Accent rule */}
-            <div className='h-2 w-48 sm:w-64 md:w-80 bg-white rounded-full shadow-[0_2px_12px_rgba(0,0,0,0.25)]' />
+            <div className='h-1.5 w-40 sm:w-56 rounded-full bg-brand-blue shadow-[0_2px_12px_rgba(0,132,255,0.5)]' />
 
             <p
-              className="
-font-display font-semibold text-white/95
-text-lg sm:text-xl md:text-3xl
+              className='
+text-white/95 font-medium
+text-lg sm:text-xl md:text-2xl
 drop-shadow-[0_2px_12px_rgba(0,0,0,0.35)]
-"
+'
             >
               Your trusted stop for fuel, food, and friendly faces.
             </p>

--- a/ClarksPNS/src/components/site/DesktopHero.tsx
+++ b/ClarksPNS/src/components/site/DesktopHero.tsx
@@ -38,7 +38,7 @@ block   /* <-- was "hidden md:block"; now renders on mobile too */
           <div className='inline-flex flex-col gap-6 md:gap-8 w-full max-w-[720px]'>
             <h1
               className="
-font-['Oswald'] font-extrabold text-white leading-[1.03]
+font-display font-extrabold text-white leading-[1.03]
 text-4xl sm:text-5xl md:text-7xl xl:text-8xl tracking-tight
 drop-shadow-[0_2px_18px_rgba(0,0,0,0.35)]
 "
@@ -55,7 +55,7 @@ drop-shadow-[0_2px_18px_rgba(0,0,0,0.35)]
 
             <p
               className="
-font-['Oswald'] font-semibold text-white/95
+font-display font-semibold text-white/95
 text-lg sm:text-xl md:text-3xl
 drop-shadow-[0_2px_12px_rgba(0,0,0,0.35)]
 "

--- a/ClarksPNS/src/components/site/Forecourt3D.tsx
+++ b/ClarksPNS/src/components/site/Forecourt3D.tsx
@@ -1,0 +1,83 @@
+// Stylized 3D forecourt model for a store page: canopy + store, plus a
+// wash bay and diesel lane when the store actually has them. The canopy
+// sign glows green while the store is open, red when closed — computed
+// from real hours. Tilts toward the cursor.
+import { useRef } from 'react'
+import { openNow, type Store } from '@/lib/stores'
+
+export default function Forecourt3D({ store }: { store: Store }) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const status = openNow(store)
+  const open = status.open !== false
+  const glow = open ? '#2fd06f' : '#ff4d4d'
+
+  const onMove = (e: React.MouseEvent) => {
+    const el = ref.current
+    if (!el || matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    const r = el.getBoundingClientRect()
+    const x = (e.clientX - r.left) / r.width - 0.5
+    const y = (e.clientY - r.top) / r.height - 0.5
+    el.style.transform = `perspective(1000px) rotateY(${x * 14}deg) rotateX(${-y * 8}deg)`
+  }
+
+  return (
+    <div
+      ref={ref}
+      onMouseMove={onMove}
+      onMouseLeave={() => {
+        if (ref.current) ref.current.style.transform = ''
+      }}
+      className='mx-auto w-full max-w-[420px] transition-transform duration-200 [transform-style:preserve-3d]'
+      aria-hidden
+    >
+      <svg viewBox='0 0 420 240'>
+        {/* lot */}
+        <ellipse cx='210' cy='218' rx='195' ry='16' fill='#0b153a' opacity='0.12' />
+        <rect x='16' y='150' width='388' height='62' rx='8' fill='#e8ecf5' />
+        {/* store */}
+        <rect x='236' y='84' width='150' height='84' rx='6' fill='#f5f7fc' stroke='#c9d2e6' />
+        <rect x='236' y='84' width='150' height='18' fill='#263B95' />
+        <rect x='240' y='87' width='90' height='12' rx='3' fill='#ffffff' />
+        <text x='285' y='97' textAnchor='middle' fill='#263B95' fontFamily='"Bebas Neue", Oswald, sans-serif' fontSize='11'>CLARK’S PUMP-N-SHOP</text>
+        <rect x='252' y='116' width='34' height='52' fill='#9fb4de' />
+        <rect x='294' y='116' width='34' height='42' fill='#bfd0ef' />
+        <rect x='336' y='116' width='34' height='42' fill='#bfd0ef' />
+        {/* canopy */}
+        <rect x='30' y='58' width='180' height='16' rx='4' fill='#263B95' />
+        <rect x='30' y='74' width='180' height='5' fill='#0084FF' />
+        <rect x='48' y='79' width='7' height='76' fill='#1a2757' />
+        <rect x='186' y='79' width='7' height='76' fill='#1a2757' />
+        {/* status sign on canopy */}
+        <rect x='92' y='40' width='56' height='22' rx='4' fill='#0b153a' />
+        <circle cx='104' cy='51' r='4' fill={glow}>
+          <animate attributeName='opacity' values='1;0.35;1' dur='2s' repeatCount='indefinite' />
+        </circle>
+        <text x='130' y='55' textAnchor='middle' fill='#ffffff' fontFamily='"Bebas Neue", Oswald, sans-serif' fontSize='11'>
+          {open ? 'OPEN' : 'CLOSED'}
+        </text>
+        {/* pumps */}
+        <g>
+          <rect x='84' y='118' width='18' height='36' rx='3' fill='#1b2f7d' />
+          <rect x='87' y='123' width='12' height='9' rx='2' fill='#0084FF' />
+          <rect x='138' y='118' width='18' height='36' rx='3' fill='#1b2f7d' />
+          <rect x='141' y='123' width='12' height='9' rx='2' fill='#0084FF' />
+        </g>
+        {/* diesel lane */}
+        {store.amenities?.diesel && (
+          <g>
+            <rect x='30' y='186' width='120' height='18' rx='4' fill='#16224e' />
+            <text x='90' y='199' textAnchor='middle' fill='#8be3ae' fontFamily='"Bebas Neue", Oswald, sans-serif' fontSize='11' letterSpacing='2'>DIESEL LANE</text>
+          </g>
+        )}
+        {/* wash bay */}
+        {store.amenities?.carWash && (
+          <g>
+            <rect x='250' y='178' width='96' height='30' rx='5' fill='#1b2f7d' />
+            <rect x='262' y='184' width='72' height='18' rx='3' fill='#0b153a' />
+            <text x='298' y='197' textAnchor='middle' fill='#7db8ff' fontFamily='"Bebas Neue", Oswald, sans-serif' fontSize='10' letterSpacing='1'>CAR WASH</text>
+          </g>
+        )}
+      </svg>
+    </div>
+  )
+}

--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -99,7 +99,8 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
       label: 'Locations',
       items: [
         { label: 'All Locations', href: toPath('Locations') },
-        { label: 'Car Wash', href: toPath('Car Wash') }
+        { label: 'Car Wash', href: toPath('Car Wash') },
+        { label: 'Beer Cave', href: '/beer-cave' }
       ]
     },
     { type: 'link' as const, label: 'Food', href: toPath('Food') },
@@ -115,8 +116,9 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
       label: 'About Us',
       items: [
         { label: 'Our Story', href: toPath('About Us') },
-        { label: 'Clarks Charity', href: '/charity' },
-        { label: 'Sponsorships', href: '/sponsorship' }
+        { label: 'Sports & Community', href: '/community' },
+        { label: 'Scholarships', href: '/scholarship' },
+        { label: 'Clarks Charity', href: '/charity' }
       ]
     }
   ]
@@ -270,6 +272,21 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
                         >
                           Car Wash
                         </NavLink>
+                        <NavLink
+                          to='/beer-cave'
+                          className={({ isActive }) =>
+                            [
+                              'block px-4 py-2 text-sm',
+                              isActive
+                                ? 'text-brand'
+                                : 'text-black hover:bg-brand/5 hover:text-brand'
+                            ].join(' ')
+                          }
+                          onClick={() => setLocOpen(false)}
+                          role='menuitem'
+                        >
+                          Beer Cave
+                        </NavLink>
                       </div>
                     </div>
                   </li>
@@ -399,6 +416,36 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
                           role='menuitem'
                         >
                           Clarks Charity
+                        </NavLink>
+                        <NavLink
+                          to='/community'
+                          className={({ isActive }) =>
+                            [
+                              'block px-4 py-2 text-sm',
+                              isActive
+                                ? 'text-brand'
+                                : 'text-black hover:bg-brand/5 hover:text-brand'
+                            ].join(' ')
+                          }
+                          onClick={() => setAboutOpen(false)}
+                          role='menuitem'
+                        >
+                          Sports & Community
+                        </NavLink>
+                        <NavLink
+                          to='/scholarship'
+                          className={({ isActive }) =>
+                            [
+                              'block px-4 py-2 text-sm',
+                              isActive
+                                ? 'text-brand'
+                                : 'text-black hover:bg-brand/5 hover:text-brand'
+                            ].join(' ')
+                          }
+                          onClick={() => setAboutOpen(false)}
+                          role='menuitem'
+                        >
+                          Scholarships
                         </NavLink>
                         {/* <NavLink
                           to='/sponsorship'

--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import LiveTicker from '@/components/site/LiveTicker'
+import SearchOverlay from '@/components/site/SearchOverlay'
 import MobileMenuDrawer from './MobileMenuDrawer'
 import logoUrl from '@/assets/images/clarks-logo.png'
 import rewardsLogoUrl from '@/assets/images/Clarks-PNS-Main-Rewards-Logo-Cropped.png'
@@ -25,6 +26,7 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
 
   // === LOCATIONS DROPDOWN (desktop) ===
   const [locOpen, setLocOpen] = useState(false)
+  const [searchOpen, setSearchOpen] = useState(false)
   const locBtnRef = useRef<HTMLButtonElement | null>(null)
   const locMenuRef = useRef<HTMLDivElement | null>(null)
 
@@ -520,8 +522,17 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
               {l.label}
             </NavLink>
           ))}
+          <button
+            type='button'
+            onClick={() => setSearchOpen(true)}
+            className="font-['Oswald'] text-[0.78rem] uppercase tracking-[0.14em] leading-none py-1 text-white/75 transition-colors hover:text-white"
+          >
+            Search
+          </button>
         </div>
       </nav>
+
+      <SearchOverlay open={searchOpen} onClose={() => setSearchOpen(false)} />
 
       {/* Mobile drawer */}
       <MobileMenuDrawer

--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -322,19 +322,16 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
                     </NavLink>
                   </li>
 
-                  {/* Fleet — diesel, kerosene & the Marathon fleet card */}
+                  {/* Fleet — straight to the Marathon fleet card portal */}
                   <li>
-                    <NavLink
-                      to='/fleet'
-                      className={({ isActive }) =>
-                        [
-                          'inline-block text-nav text-center leading-none py-2',
-                          isActive ? 'text-brand' : 'text-text hover:text-brand'
-                        ].join(' ')
-                      }
+                    <a
+                      href='https://www.marathonfleetcard.com/associations/?cc=M00528'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='inline-block text-nav text-center leading-none py-2 text-text hover:text-brand'
                     >
                       Fleet
-                    </NavLink>
+                    </a>
                   </li>
 
                   {/* About dropdown */}

--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -502,12 +502,12 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
             { to: '/food', label: 'Food & Menus' },
             { to: '/clarks-rewards', label: 'Rewards' },
             { to: '/car-wash', label: 'Car Wash' },
-            { to: '/beer-cave', label: 'Beer Cave' },
             { to: '/community', label: 'Sports & Community' },
             { to: '/scholarship', label: 'Scholarships' },
             { to: '/charity', label: 'Charity' },
             { to: '/fleet', label: 'Fleet & Diesel' },
-            { to: '/careers', label: 'Careers' }
+            { to: '/careers', label: 'Careers' },
+            { to: '/beer-cave', label: 'Beer Cave' }
           ].map(l => (
             <NavLink
               key={l.to}

--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -1,6 +1,7 @@
 // src/components/site/HeaderNav.tsx
 import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
+import LiveTicker from '@/components/site/LiveTicker'
 import MobileMenuDrawer from './MobileMenuDrawer'
 import logoUrl from '@/assets/images/clarks-logo.png'
 import rewardsLogoUrl from '@/assets/images/Clarks-PNS-Main-Rewards-Logo-Cropped.png'
@@ -120,6 +121,7 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
 
   return (
     <header className='sticky top-0 z-header w-full'>
+      <LiveTicker />
       <div className='bg-surface shadow-soft rounded-b-2xl'>
         {/* --- MOBILE BAR (<= md) --- */}
         <div className='md:hidden h-16 grid grid-cols-[auto_1fr_auto] items-center px-3'>

--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -513,7 +513,7 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
               to={l.to}
               className={({ isActive }) =>
                 [
-                  "font-['Oswald'] text-[0.78rem] uppercase tracking-[0.14em] leading-none py-1 transition-colors",
+                  "font-display text-[0.78rem] uppercase tracking-[0.14em] leading-none py-1 transition-colors",
                   isActive ? 'text-white' : 'text-white/75 hover:text-white'
                 ].join(' ')
               }

--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -105,12 +105,7 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
     },
     { type: 'link' as const, label: 'Food', href: toPath('Food') },
     { type: 'link' as const, label: 'Careers', href: toPath('Careers') },
-    {
-      type: 'link' as const,
-      label: 'Fleet Card',
-      href: 'https://www.marathonfleetcard.com/associations/?cc=M00528',
-      external: true
-    },
+    { type: 'link' as const, label: 'Fleet', href: '/fleet' },
     {
       type: 'group' as const,
       label: 'About Us',
@@ -325,16 +320,19 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
                     </NavLink>
                   </li>
 
-                  {/* Fleet Card — external link, WEX/Marathon association tracking */}
+                  {/* Fleet — diesel, kerosene & the Marathon fleet card */}
                   <li>
-                    <a
-                      href='https://www.marathonfleetcard.com/associations/?cc=M00528'
-                      target='_blank'
-                      rel='noopener noreferrer'
-                      className='inline-block text-nav text-center leading-none py-2 text-text hover:text-brand focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand'
+                    <NavLink
+                      to='/fleet'
+                      className={({ isActive }) =>
+                        [
+                          'inline-block text-nav text-center leading-none py-2',
+                          isActive ? 'text-brand' : 'text-text hover:text-brand'
+                        ].join(' ')
+                      }
                     >
-                      Fleet Card
-                    </a>
+                      Fleet
+                    </NavLink>
                   </li>
 
                   {/* About dropdown */}
@@ -494,6 +492,37 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
           </div>
         </div>
       </div>
+
+      {/* Quick links — every destination visible, no dropdown hunting */}
+      <nav aria-label='Quick links' className='hidden md:block bg-brand'>
+        <div className='container mx-auto flex flex-wrap items-center justify-center gap-x-6 gap-y-1 px-6 py-2 md:px-10'>
+          {[
+            { to: '/locations', label: 'Locations' },
+            { to: '/food', label: 'Food & Menus' },
+            { to: '/clarks-rewards', label: 'Rewards' },
+            { to: '/car-wash', label: 'Car Wash' },
+            { to: '/beer-cave', label: 'Beer Cave' },
+            { to: '/community', label: 'Sports & Community' },
+            { to: '/scholarship', label: 'Scholarships' },
+            { to: '/charity', label: 'Charity' },
+            { to: '/fleet', label: 'Fleet & Diesel' },
+            { to: '/careers', label: 'Careers' }
+          ].map(l => (
+            <NavLink
+              key={l.to}
+              to={l.to}
+              className={({ isActive }) =>
+                [
+                  "font-['Oswald'] text-[0.78rem] uppercase tracking-[0.14em] leading-none py-1 transition-colors",
+                  isActive ? 'text-white' : 'text-white/75 hover:text-white'
+                ].join(' ')
+              }
+            >
+              {l.label}
+            </NavLink>
+          ))}
+        </div>
+      </nav>
 
       {/* Mobile drawer */}
       <MobileMenuDrawer

--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import LiveTicker from '@/components/site/LiveTicker'
 import SearchOverlay from '@/components/site/SearchOverlay'
+import NoticeBanner from '@/components/site/NoticeBanner'
 import MobileMenuDrawer from './MobileMenuDrawer'
 import logoUrl from '@/assets/images/clarks-logo.png'
 import rewardsLogoUrl from '@/assets/images/Clarks-PNS-Main-Rewards-Logo-Cropped.png'
@@ -124,6 +125,7 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
   return (
     <header className='sticky top-0 z-header w-full'>
       <LiveTicker />
+      <NoticeBanner />
       <div className='bg-surface shadow-soft rounded-b-2xl'>
         {/* --- MOBILE BAR (<= md) --- */}
         <div className='md:hidden h-16 grid grid-cols-[auto_1fr_auto] items-center px-3'>

--- a/ClarksPNS/src/components/site/HometownCinema.tsx
+++ b/ClarksPNS/src/components/site/HometownCinema.tsx
@@ -11,16 +11,16 @@ const FILM_POSTER = `${CDN}/image/upload/f_auto,q_auto,w_1280/v1/clarks/stores/$
 
 const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }> = [
   {
-    slug: 'westwood-ashland-ky',
-    name: 'Westwood',
+    slug: 'greenup-ave-ashland-ky',
+    name: 'Greenup Ave',
     place: 'Ashland, KY',
-    tag: 'Where it all started — 1976'
+    tag: 'Our Ashland hometown'
   },
   {
-    slug: 'clays-mill-rd-lexington-ky',
-    name: 'Clays Mill Rd',
+    slug: 'lucille-dr-lexington-ky',
+    name: 'Lucille Dr',
     place: 'Lexington, KY',
-    tag: 'Growing in the Bluegrass'
+    tag: 'Our newest store'
   },
   {
     slug: 'huntington-huntington-wv',
@@ -29,9 +29,9 @@ const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }
     tag: 'West Virginia proud'
   },
   {
-    slug: 'ironton-ironton-oh',
-    name: 'Ironton',
-    place: 'Ironton, OH',
+    slug: 'south-point-so-point-oh',
+    name: 'South Point',
+    place: 'South Point, OH',
     tag: 'Ohio proud'
   }
 ]

--- a/ClarksPNS/src/components/site/HometownCinema.tsx
+++ b/ClarksPNS/src/components/site/HometownCinema.tsx
@@ -91,10 +91,10 @@ export default function HometownCinema() {
       </div>
 
       <div className='container relative z-[1] mx-auto px-6 py-20 md:px-10 md:py-28'>
-        <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-white/70">
+        <div className="font-display text-xs uppercase tracking-[0.3em] text-white/70">
           Filmed over our own stores
         </div>
-        <h2 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight md:text-6xl">
+        <h2 className="mt-2 font-display text-4xl font-bold leading-tight md:text-6xl">
           Sixty-three hometowns.
           <br />
           One promise.
@@ -159,7 +159,7 @@ function TiltCard({
         />
       </div>
       <div className='absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 to-transparent p-4 pt-10'>
-        <div className="font-['Oswald'] text-lg font-bold leading-tight">
+        <div className="font-display text-lg font-bold leading-tight">
           {store.name}
         </div>
         <div className='text-sm text-white/75'>{store.place}</div>

--- a/ClarksPNS/src/components/site/HometownCinema.tsx
+++ b/ClarksPNS/src/components/site/HometownCinema.tsx
@@ -17,10 +17,10 @@ const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }
     tag: 'Where it all started — 1976'
   },
   {
-    slug: 'greenup-ave-ashland-ky',
-    name: 'Greenup Ave',
-    place: 'Ashland, KY',
-    tag: 'Hometown flagship'
+    slug: 'clays-mill-rd-lexington-ky',
+    name: 'Clays Mill Rd',
+    place: 'Lexington, KY',
+    tag: 'Growing in the Bluegrass'
   },
   {
     slug: 'huntington-huntington-wv',
@@ -95,14 +95,12 @@ export default function HometownCinema() {
           Filmed over our own stores
         </div>
         <h2 className="mt-2 font-display text-4xl font-bold leading-tight md:text-6xl">
-          Sixty-three hometowns.
-          <br />
-          One promise.
+          Proudly serving you.
         </h2>
         <p className='mt-4 max-w-prose text-lg text-white/85'>
           Kentucky. Ohio. West Virginia. Every Clark’s has its own page —
           real photos, real video, live hours, and a map that knows how far
-          away you are. Wherever you are in the Tri-State, you’re home.
+          away you are.
         </p>
 
         {/* Showcase cards */}

--- a/ClarksPNS/src/components/site/HometownCinema.tsx
+++ b/ClarksPNS/src/components/site/HometownCinema.tsx
@@ -29,10 +29,10 @@ const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }
     tag: 'West Virginia proud'
   },
   {
-    slug: 'lexington-lexington-ky',
-    name: 'W Main St',
-    place: 'Lexington, KY',
-    tag: 'Downtown Lexington'
+    slug: 'ironton-ironton-oh',
+    name: 'Ironton',
+    place: 'Ironton, OH',
+    tag: 'Ohio proud'
   }
 ]
 
@@ -95,14 +95,14 @@ export default function HometownCinema() {
           Filmed over our own stores
         </div>
         <h2 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight md:text-6xl">
-          Sixty-five hometowns.
+          Sixty-three hometowns.
           <br />
           One promise.
         </h2>
         <p className='mt-4 max-w-prose text-lg text-white/85'>
-          Every Clark’s has its own page — real photos, real video, live
-          hours, and a map that knows how far away you are. Fly over a few
-          of ours.
+          Kentucky. Ohio. West Virginia. Every Clark’s has its own page —
+          real photos, real video, live hours, and a map that knows how far
+          away you are. Wherever you are in the Tri-State, you’re home.
         </p>
 
         {/* Showcase cards */}

--- a/ClarksPNS/src/components/site/HometownCinema.tsx
+++ b/ClarksPNS/src/components/site/HometownCinema.tsx
@@ -9,12 +9,13 @@ const FILM_SLUG = 'catlettsburg-catlettsburg-ky'
 const FILM = `${CDN}/video/upload/w_1280,q_auto:eco/v1/clarks/stores/${FILM_SLUG}/drone.mp4`
 const FILM_POSTER = `${CDN}/image/upload/f_auto,q_auto,w_1280/v1/clarks/stores/${FILM_SLUG}/poster.jpg`
 
-const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }> = [
+const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string; img?: string }> = [
   {
-    slug: 'greenup-ave-ashland-ky',
-    name: 'Greenup Ave',
-    place: 'Ashland, KY',
-    tag: 'Our Ashland hometown'
+    slug: 'westwood-ashland-ky',
+    name: 'Westwood',
+    place: 'Fairview — Ashland, KY',
+    tag: 'The flagship — where we started',
+    img: 'gallery/09.jpg'
   },
   {
     slug: 'winchester-road-lexington-ky',
@@ -35,21 +36,21 @@ const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }
     tag: 'Dog park on site'
   },
   {
-    slug: 'huntington-huntington-wv',
-    name: 'Huntington',
+    slug: 'hal-greer-huntington-wv',
+    name: 'Hal Greer Blvd',
     place: 'Huntington, WV',
     tag: 'West Virginia proud'
   },
   {
-    slug: 'ironton-ironton-oh',
-    name: 'Ironton',
-    place: 'Ironton, OH',
+    slug: 'south-point-so-point-oh',
+    name: 'South Point',
+    place: 'South Point, OH',
     tag: 'Ohio proud'
   }
 ]
 
-const heroUrl = (slug: string) =>
-  `${CDN}/image/upload/f_auto,q_auto,w_800/v1/clarks/stores/${slug}/hero.jpg`
+const heroUrl = (slug: string, img?: string) =>
+  `${CDN}/image/upload/f_auto,q_auto,w_800/v1/clarks/stores/${slug}/${img || 'hero.jpg'}`
 
 export default function HometownCinema() {
   const secRef = useRef<HTMLElement | null>(null)
@@ -136,7 +137,7 @@ export default function HometownCinema() {
 function TiltCard({
   store
 }: {
-  store: { slug: string; name: string; place: string; tag: string }
+  store: { slug: string; name: string; place: string; tag: string; img?: string }
 }) {
   const ref = useRef<HTMLAnchorElement | null>(null)
 
@@ -162,7 +163,7 @@ function TiltCard({
     >
       <div className='aspect-[4/3] overflow-hidden'>
         <img
-          src={heroUrl(store.slug)}
+          src={heroUrl(store.slug, store.img)}
           alt={`Clark’s Pump-N-Shop — ${store.name}, ${store.place}`}
           loading='lazy'
           className='h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.05]'

--- a/ClarksPNS/src/components/site/HometownCinema.tsx
+++ b/ClarksPNS/src/components/site/HometownCinema.tsx
@@ -1,0 +1,170 @@
+// Full-bleed cinematic band: real drone footage over a Clark's store,
+// then a 3D-tilt showcase of real storefronts linking to their pages.
+// Video only loads when the section scrolls into view (poster until then).
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+const CDN = 'https://res.cloudinary.com/yzpytwu5'
+const FILM_SLUG = 'catlettsburg-catlettsburg-ky'
+const FILM = `${CDN}/video/upload/w_1280,q_auto:eco/v1/clarks/stores/${FILM_SLUG}/drone.mp4`
+const FILM_POSTER = `${CDN}/image/upload/f_auto,q_auto,w_1280/v1/clarks/stores/${FILM_SLUG}/poster.jpg`
+
+const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }> = [
+  {
+    slug: 'westwood-ashland-ky',
+    name: 'Westwood',
+    place: 'Ashland, KY',
+    tag: 'Where it all started — 1976'
+  },
+  {
+    slug: 'greenup-ave-ashland-ky',
+    name: 'Greenup Ave',
+    place: 'Ashland, KY',
+    tag: 'Hometown flagship'
+  },
+  {
+    slug: 'huntington-huntington-wv',
+    name: 'Huntington',
+    place: 'Huntington, WV',
+    tag: 'West Virginia proud'
+  },
+  {
+    slug: 'lexington-lexington-ky',
+    name: 'W Main St',
+    place: 'Lexington, KY',
+    tag: 'Downtown Lexington'
+  }
+]
+
+const heroUrl = (slug: string) =>
+  `${CDN}/image/upload/f_auto,q_auto,w_800/v1/clarks/stores/${slug}/hero.jpg`
+
+export default function HometownCinema() {
+  const secRef = useRef<HTMLElement | null>(null)
+  const [playFilm, setPlayFilm] = useState(false)
+
+  useEffect(() => {
+    const el = secRef.current
+    if (!el) return
+    const io = new IntersectionObserver(
+      es => {
+        if (es.some(e => e.isIntersecting)) {
+          setPlayFilm(true)
+          io.disconnect()
+        }
+      },
+      { rootMargin: '200px' }
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [])
+
+  return (
+    <section
+      ref={secRef}
+      aria-label='Our hometowns'
+      className='relative isolate overflow-hidden bg-black text-white'
+    >
+      {/* Film layer */}
+      <div className='absolute inset-0'>
+        {playFilm ? (
+          <video
+            className='h-full w-full object-cover opacity-60'
+            autoPlay
+            muted
+            loop
+            playsInline
+            preload='none'
+            poster={FILM_POSTER}
+          >
+            <source src={FILM} type='video/mp4' />
+          </video>
+        ) : (
+          <img
+            src={FILM_POSTER}
+            alt=''
+            aria-hidden
+            className='h-full w-full object-cover opacity-60'
+          />
+        )}
+        <div className='absolute inset-0 bg-gradient-to-b from-black/70 via-black/30 to-black/80' />
+      </div>
+
+      <div className='container relative z-[1] mx-auto px-6 py-20 md:px-10 md:py-28'>
+        <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-white/70">
+          Filmed over our own stores
+        </div>
+        <h2 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight md:text-6xl">
+          Sixty-five hometowns.
+          <br />
+          One promise.
+        </h2>
+        <p className='mt-4 max-w-prose text-lg text-white/85'>
+          Every Clark’s has its own page — real photos, real video, live
+          hours, and a map that knows how far away you are. Fly over a few
+          of ours.
+        </p>
+
+        {/* Showcase cards */}
+        <div className='mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 [perspective:1200px]'>
+          {SHOWCASE.map(s => (
+            <TiltCard key={s.slug} store={s} />
+          ))}
+        </div>
+
+        <Link
+          to='/locations'
+          className='mt-10 inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 font-semibold text-brand transition-transform hover:-translate-y-0.5'
+        >
+          Find your Clark’s
+        </Link>
+      </div>
+    </section>
+  )
+}
+
+function TiltCard({
+  store
+}: {
+  store: { slug: string; name: string; place: string; tag: string }
+}) {
+  const ref = useRef<HTMLAnchorElement | null>(null)
+
+  const onMove = (e: React.MouseEvent) => {
+    const el = ref.current
+    if (!el || matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    const r = el.getBoundingClientRect()
+    const x = (e.clientX - r.left) / r.width - 0.5
+    const y = (e.clientY - r.top) / r.height - 0.5
+    el.style.transform = `rotateY(${x * 8}deg) rotateX(${-y * 6}deg) translateZ(8px)`
+  }
+  const onLeave = () => {
+    if (ref.current) ref.current.style.transform = ''
+  }
+
+  return (
+    <Link
+      ref={ref}
+      to={`/locations/${store.slug}`}
+      onMouseMove={onMove}
+      onMouseLeave={onLeave}
+      className='group relative block overflow-hidden rounded-2xl border border-white/15 bg-white/5 transition-[transform,border-color] duration-200 [transform-style:preserve-3d] hover:border-white/40'
+    >
+      <div className='aspect-[4/3] overflow-hidden'>
+        <img
+          src={heroUrl(store.slug)}
+          alt={`Clark’s Pump-N-Shop — ${store.name}, ${store.place}`}
+          loading='lazy'
+          className='h-full w-full object-cover transition-transform duration-500 group-hover:scale-[1.05]'
+        />
+      </div>
+      <div className='absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 to-transparent p-4 pt-10'>
+        <div className="font-['Oswald'] text-lg font-bold leading-tight">
+          {store.name}
+        </div>
+        <div className='text-sm text-white/75'>{store.place}</div>
+        <div className='mt-1 text-xs text-white/60'>{store.tag}</div>
+      </div>
+    </Link>
+  )
+}

--- a/ClarksPNS/src/components/site/HometownCinema.tsx
+++ b/ClarksPNS/src/components/site/HometownCinema.tsx
@@ -17,10 +17,22 @@ const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }
     tag: 'Our Ashland hometown'
   },
   {
+    slug: 'winchester-road-lexington-ky',
+    name: 'Winchester Road',
+    place: 'Lexington, KY',
+    tag: 'Brand new in Lexington'
+  },
+  {
     slug: 'lucille-dr-lexington-ky',
     name: 'Lucille Dr',
     place: 'Lexington, KY',
     tag: 'Our newest store'
+  },
+  {
+    slug: 'midway-midway-ky',
+    name: 'Midway',
+    place: 'Midway, KY',
+    tag: 'Dog park on site'
   },
   {
     slug: 'huntington-huntington-wv',
@@ -29,9 +41,9 @@ const SHOWCASE: Array<{ slug: string; name: string; place: string; tag: string }
     tag: 'West Virginia proud'
   },
   {
-    slug: 'south-point-so-point-oh',
-    name: 'South Point',
-    place: 'South Point, OH',
+    slug: 'ironton-ironton-oh',
+    name: 'Ironton',
+    place: 'Ironton, OH',
     tag: 'Ohio proud'
   }
 ]
@@ -104,7 +116,7 @@ export default function HometownCinema() {
         </p>
 
         {/* Showcase cards */}
-        <div className='mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4 [perspective:1200px]'>
+        <div className='mt-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 [perspective:1200px]'>
           {SHOWCASE.map(s => (
             <TiltCard key={s.slug} store={s} />
           ))}

--- a/ClarksPNS/src/components/site/Icons.tsx
+++ b/ClarksPNS/src/components/site/Icons.tsx
@@ -1,0 +1,118 @@
+// Brand icon set — drawn line icons, no emojis anywhere in the UI.
+// 24x24 viewBox, stroke-based, inherit currentColor.
+import type { SVGProps } from 'react'
+
+const base = {
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.8,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  'aria-hidden': true
+}
+
+type P = SVGProps<SVGSVGElement>
+
+export function IconShine(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <path d='M12 3v4M12 17v4M3 12h4M17 12h4M5.6 5.6l2.8 2.8M15.6 15.6l2.8 2.8M18.4 5.6l-2.8 2.8M8.4 15.6l-2.8 2.8' />
+    </svg>
+  )
+}
+
+export function IconFoam(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <circle cx='7' cy='14' r='3.4' />
+      <circle cx='14.5' cy='10' r='4.6' />
+      <circle cx='17.5' cy='17' r='2.6' />
+    </svg>
+  )
+}
+
+export function IconFast(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <path d='M13 3 5 13.5h5L11 21l8-10.5h-5L13 3z' />
+    </svg>
+  )
+}
+
+export function IconDrop(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <path d='M12 3.5c3.2 4.2 6 7.6 6 10.7a6 6 0 1 1-12 0c0-3.1 2.8-6.5 6-10.7z' />
+      <path d='M9.5 14.5a2.8 2.8 0 0 0 2 2.6' />
+    </svg>
+  )
+}
+
+export function IconPump(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <rect x='4' y='4' width='9' height='16.5' rx='1.5' />
+      <rect x='6.4' y='6.5' width='4.2' height='4' rx='0.8' />
+      <path d='M13 9h2.6a2 2 0 0 1 2 2v5.4a1.6 1.6 0 0 0 3.2 0V9.8L18.6 7' />
+      <path d='M2.5 20.5h12' />
+    </svg>
+  )
+}
+
+export function IconCoffee(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <path d='M4 9h12v6.5A4.5 4.5 0 0 1 11.5 20h-3A4.5 4.5 0 0 1 4 15.5V9z' />
+      <path d='M16 10.5h1.6a2.4 2.4 0 0 1 0 4.8H16' />
+      <path d='M8 3.8c0 1-.9 1.2-.9 2.2M12 3.8c0 1-.9 1.2-.9 2.2' />
+    </svg>
+  )
+}
+
+export function IconGift(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <rect x='4' y='9' width='16' height='11.5' rx='1.5' />
+      <path d='M12 9v11.5M4 13.5h16' />
+      <path d='M12 9c-1.8 0-4.4-.6-4.4-2.7A2.2 2.2 0 0 1 12 5.6 2.2 2.2 0 0 1 16.4 6.3C16.4 8.4 13.8 9 12 9z' />
+    </svg>
+  )
+}
+
+export function IconSnow(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <path d='M12 3v18M4.2 7.5l15.6 9M19.8 7.5l-15.6 9' />
+      <path d='M12 3l-2 2.2M12 3l2 2.2M12 21l-2-2.2M12 21l2-2.2' />
+    </svg>
+  )
+}
+
+export function IconClose(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <path d='M6 6l12 12M18 6L6 18' />
+    </svg>
+  )
+}
+
+export function IconTrophy(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <path d='M8 4h8v5a4 4 0 0 1-8 0V4z' />
+      <path d='M8 5H5a3 3 0 0 0 3 4.5M16 5h3a3 3 0 0 1-3 4.5' />
+      <path d='M12 13v3.5M8.5 20.5h7M10 16.5h4v4h-4z' />
+    </svg>
+  )
+}
+
+export function IconCap(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <path d='M12 5 2.5 9.5 12 14l9.5-4.5L12 5z' />
+      <path d='M6.5 11.7V16c0 1.4 2.5 2.8 5.5 2.8s5.5-1.4 5.5-2.8v-4.3' />
+      <path d='M21.5 9.5V15' />
+    </svg>
+  )
+}

--- a/ClarksPNS/src/components/site/LiveTicker.tsx
+++ b/ClarksPNS/src/components/site/LiveTicker.tsx
@@ -1,0 +1,127 @@
+// LIVE ticker — ESPN-style feed across the top of every page.
+// Scrolls all 63 stores with real-time open/closed status computed from
+// each store's actual hours. Built price-ready: when Clark's pricing
+// feed comes online, add `price` to TickerItem and it renders in-line.
+// No fabricated data, ever.
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { allStores, openNow, type Store } from '@/lib/stores'
+
+type TickerItem = {
+  store: Store
+  open: boolean | null
+  label: string
+  // price?: string  <- reserved for Clark's live price feed
+}
+
+function buildItems(): TickerItem[] {
+  return allStores
+    .filter(s => s.lat != null)
+    .map(store => {
+      const st = openNow(store)
+      return { store, open: st.open, label: st.label }
+    })
+}
+
+const SPEED = 0.55 // px per frame
+
+export default function LiveTicker() {
+  const [items, setItems] = useState<TickerItem[]>(buildItems)
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const posRef = useRef(0)
+  const pausedRef = useRef(false)
+
+  // Recompute open/closed every minute so the feed stays truthful.
+  useEffect(() => {
+    const t = window.setInterval(() => setItems(buildItems()), 60_000)
+    return () => window.clearInterval(t)
+  }, [])
+
+  // Continuous marquee (content rendered twice, wraps at half width).
+  useEffect(() => {
+    const reduced = window.matchMedia?.(
+      '(prefers-reduced-motion: reduce)'
+    )?.matches
+    if (reduced) return
+    const tick = () => {
+      const el = scrollerRef.current
+      if (el && !pausedRef.current) {
+        if (Math.abs(el.scrollLeft - posRef.current) > 2) {
+          posRef.current = el.scrollLeft
+        }
+        const half = el.scrollWidth / 2
+        let next = posRef.current + SPEED
+        if (half > 0 && next >= half) next -= half
+        posRef.current = next
+        el.scrollLeft = next
+      }
+      rafRef.current = requestAnimationFrame(tick)
+    }
+    rafRef.current = requestAnimationFrame(tick)
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+    }
+  }, [])
+
+  return (
+    <div
+      aria-label='Live store status feed'
+      className='flex h-9 items-stretch overflow-hidden bg-[#0b153a] text-white'
+    >
+      {/* LIVE badge */}
+      <div className='z-[1] flex shrink-0 items-center gap-2 bg-brand px-3 shadow-[4px_0_12px_rgba(0,0,0,0.4)]'>
+        <span className='relative flex h-2 w-2'>
+          <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-[#ff4d4d] opacity-75' />
+          <span className='relative inline-flex h-2 w-2 rounded-full bg-[#ff4d4d]' />
+        </span>
+        <span className='font-display text-sm tracking-[0.2em]'>LIVE</span>
+        <span className='hidden font-display text-sm tracking-[0.12em] text-white/60 sm:inline'>
+          CLARK’S ACROSS THE TRI-STATE
+        </span>
+      </div>
+
+      {/* Feed */}
+      <div
+        ref={scrollerRef}
+        onMouseEnter={() => {
+          pausedRef.current = true
+        }}
+        onMouseLeave={() => {
+          pausedRef.current = false
+        }}
+        className='flex items-center gap-0 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden'
+      >
+        {[...items, ...items].map((it, i) => (
+          <Link
+            key={`${it.store.slug}-${i}`}
+            to={`/locations/${it.store.slug}`}
+            tabIndex={i >= items.length ? -1 : undefined}
+            aria-hidden={i >= items.length || undefined}
+            className='group flex shrink-0 items-center gap-2 border-r border-white/10 px-4 text-[0.72rem] leading-none'
+          >
+            <span
+              aria-hidden
+              className={`inline-block h-1.5 w-1.5 rounded-full ${
+                it.open === false ? 'bg-[#ff4d4d]' : 'bg-[#2fd06f]'
+              }`}
+            />
+            <span className='font-display text-sm tracking-[0.08em] text-white group-hover:text-[#7db8ff]'>
+              {it.store.name.toUpperCase()}
+            </span>
+            <span className='text-white/50'>
+              {it.store.city}, {(it.store.state || '').toUpperCase()}
+            </span>
+            <span
+              className={
+                it.open === false ? 'text-[#ff8a8a]' : 'text-[#8be3ae]'
+              }
+            >
+              {it.label.toUpperCase()}
+            </span>
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/ClarksPNS/src/components/site/LiveTicker.tsx
+++ b/ClarksPNS/src/components/site/LiveTicker.tsx
@@ -77,7 +77,7 @@ export default function LiveTicker() {
         </span>
         <span className='font-display text-sm tracking-[0.2em]'>LIVE</span>
         <span className='hidden font-display text-sm tracking-[0.12em] text-white/60 sm:inline'>
-          CLARK’S ACROSS THE TRI-STATE
+          ALL CLARK’S PNS LOCATIONS
         </span>
       </div>
 

--- a/ClarksPNS/src/components/site/MobileHero.tsx
+++ b/ClarksPNS/src/components/site/MobileHero.tsx
@@ -38,7 +38,7 @@ export default function MobileHero({
 
       {/* Text */}
       <div className="text-center space-y-3 mt-6 px-4">
-        <h1 className="font-['Oswald'] font-bold leading-tight text-[clamp(1.5rem,1.1rem+2.2vw,2rem)]">
+        <h1 className="font-display font-bold leading-tight text-[clamp(1.5rem,1.1rem+2.2vw,2rem)]">
           {title}
         </h1>
         {subtitle && (

--- a/ClarksPNS/src/components/site/NoticeBanner.tsx
+++ b/ClarksPNS/src/components/site/NoticeBanner.tsx
@@ -1,0 +1,45 @@
+// Sitewide notice — controlled by /notice.json in the repo. Flip
+// "active" to true, write the message, deploy (or edit via the GitHub
+// API — see ATLAS-INTEGRATION.md) and every page shows the banner.
+import { useEffect, useState } from 'react'
+
+type Notice = {
+  active: boolean
+  message: string
+  link?: string
+  linkLabel?: string
+  tone?: 'info' | 'alert'
+}
+
+export default function NoticeBanner() {
+  const [notice, setNotice] = useState<Notice | null>(null)
+
+  useEffect(() => {
+    fetch('/notice.json', { cache: 'no-store' })
+      .then(r => (r.ok ? r.json() : null))
+      .then(n => {
+        if (n && n.active && n.message) setNotice(n)
+      })
+      .catch(() => {})
+  }, [])
+
+  if (!notice) return null
+
+  const alert = notice.tone === 'alert'
+  return (
+    <div
+      role='status'
+      className={`${alert ? 'bg-[#a3261e]' : 'bg-brand-blue'} px-4 py-2 text-center text-white`}
+    >
+      <span className='text-sm font-medium'>{notice.message}</span>
+      {notice.link && (
+        <a
+          href={notice.link}
+          className='ml-3 text-sm font-semibold underline underline-offset-2'
+        >
+          {notice.linkLabel || 'Details'}
+        </a>
+      )}
+    </div>
+  )
+}

--- a/ClarksPNS/src/components/site/RoadTrip.tsx
+++ b/ClarksPNS/src/components/site/RoadTrip.tsx
@@ -1,0 +1,143 @@
+// Road Trip mode — geocode a start and end, then list every Clark's
+// within ~4 miles of the straight-line corridor, ordered along the
+// route. Uses the same Google geocoder as the Locations search.
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { allStores, namedKitchens, type Store } from '@/lib/stores'
+import { track } from '@/lib/track'
+
+const GOOGLE_KEY = (
+  import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined
+)?.trim()
+
+type LatLng = { lat: number; lng: number }
+type RouteHit = { store: Store; t: number; off: number }
+
+async function geocode(q: string): Promise<LatLng | null> {
+  if (!GOOGLE_KEY) return null
+  const r = await fetch(
+    `https://maps.googleapis.com/maps/api/geocode/json?address=${encodeURIComponent(
+      q + ', USA'
+    )}&key=${GOOGLE_KEY}`
+  )
+  const d = await r.json()
+  const loc = d?.results?.[0]?.geometry?.location
+  return loc ? { lat: loc.lat, lng: loc.lng } : null
+}
+
+/** Distance (miles) from point P to segment AB + progress t along it,
+ *  using an equirectangular projection (fine at Tri-State scale). */
+function corridor(a: LatLng, b: LatLng, p: LatLng) {
+  const kx = Math.cos((((a.lat + b.lat) / 2) * Math.PI) / 180) * 69.172
+  const ky = 69.055
+  const ax = a.lng * kx
+  const ay = a.lat * ky
+  const bx = b.lng * kx
+  const by = b.lat * ky
+  const px = p.lng * kx
+  const py = p.lat * ky
+  const dx = bx - ax
+  const dy = by - ay
+  const len2 = dx * dx + dy * dy || 1
+  let t = ((px - ax) * dx + (py - ay) * dy) / len2
+  t = Math.max(0, Math.min(1, t))
+  const cx = ax + t * dx
+  const cy = ay + t * dy
+  return { off: Math.hypot(px - cx, py - cy), t }
+}
+
+export default function RoadTrip() {
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+  const [hits, setHits] = useState<RouteHit[] | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+
+  const go = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!from.trim() || !to.trim()) return
+    setBusy(true)
+    setErr('')
+    try {
+      const [A, B] = await Promise.all([geocode(from), geocode(to)])
+      if (!A || !B) {
+        setErr('Could not find one of those places — try a city and state.')
+        setHits(null)
+        return
+      }
+      const out: RouteHit[] = []
+      for (const s of allStores) {
+        if (s.lat == null || s.lng == null) continue
+        const { off, t } = corridor(A, B, { lat: s.lat, lng: s.lng })
+        if (off <= 4) out.push({ store: s, t, off })
+      }
+      out.sort((x, y) => x.t - y.t)
+      setHits(out)
+      track('road_trip', { from, to, found: out.length })
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className='mt-8 rounded-2xl border border-white/15 bg-white/5 p-5 md:p-6'>
+      <h2 className='font-display text-2xl md:text-3xl'>Road trip?</h2>
+      <p className='mt-1 text-sm text-white/70'>
+        Tell us where you’re headed — we’ll line up every Clark’s along the
+        way.
+      </p>
+      <form onSubmit={go} className='mt-4 flex flex-col gap-3 sm:flex-row'>
+        <input
+          value={from}
+          onChange={e => setFrom(e.target.value)}
+          placeholder='From — e.g. Ashland KY'
+          className='h-12 flex-1 rounded-xl border border-white/20 bg-white px-4 text-black outline-none placeholder:text-black/40 focus:ring-2 focus:ring-brand-blue'
+        />
+        <input
+          value={to}
+          onChange={e => setTo(e.target.value)}
+          placeholder='To — e.g. Lexington KY'
+          className='h-12 flex-1 rounded-xl border border-white/20 bg-white px-4 text-black outline-none placeholder:text-black/40 focus:ring-2 focus:ring-brand-blue'
+        />
+        <button
+          type='submit'
+          disabled={busy || !GOOGLE_KEY}
+          className='h-12 shrink-0 rounded-xl bg-white px-6 font-semibold text-brand transition-transform hover:-translate-y-0.5 disabled:opacity-50'
+        >
+          {busy ? 'Routing…' : 'Line them up'}
+        </button>
+      </form>
+      {err && <p className='mt-3 text-sm text-[#ff8a8a]'>{err}</p>}
+      {hits && (
+        <div className='mt-5'>
+          <div className='font-display text-lg tracking-[0.06em] text-[#8be3ae]'>
+            {hits.length} CLARK’S ON YOUR ROUTE
+          </div>
+          <ol className='mt-3 space-y-2'>
+            {hits.map(h => (
+              <li key={h.store.slug}>
+                <Link
+                  to={`/locations/${h.store.slug}`}
+                  className='group flex flex-wrap items-baseline gap-x-3 gap-y-1 rounded-xl border border-white/10 bg-white/5 px-4 py-2.5 transition-colors hover:border-white/40'
+                >
+                  <span className='font-display text-lg text-white group-hover:text-[#7db8ff]'>
+                    {h.store.name}
+                  </span>
+                  <span className='text-sm text-white/60'>
+                    {h.store.city}, {(h.store.state || '').toUpperCase()} ·{' '}
+                    {h.off.toFixed(1)} mi off route
+                  </span>
+                  {namedKitchens(h.store).length > 0 && (
+                    <span className='text-xs text-[#8be3ae]'>
+                      {namedKitchens(h.store).join(' · ')}
+                    </span>
+                  )}
+                </Link>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ClarksPNS/src/components/site/SearchOverlay.tsx
+++ b/ClarksPNS/src/components/site/SearchOverlay.tsx
@@ -1,0 +1,151 @@
+// Site search — press the search button (or "/") and type anything:
+// a town, a store, "beer cave", "diesel", "pizza". Results come from
+// the real store index and the site's pages. Client-side, instant.
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { allStores, namedKitchens } from '@/lib/stores'
+import { IconClose } from '@/components/site/Icons'
+
+type Hit = { label: string; sub: string; href: string }
+
+const PAGES: Hit[] = [
+  { label: 'All locations', sub: 'Find a Clark’s near you', href: '/locations' },
+  { label: 'Food & menus', sub: 'Five in-store kitchens', href: '/food' },
+  { label: 'Krispy Krunchy Chicken', sub: 'Menu & stores', href: '/food/krispy-krunchy' },
+  { label: 'Hangar 54 Pizza', sub: 'Menu & stores', href: '/food/hangar-54' },
+  { label: 'Clark’s Café', sub: 'Breakfast menu & stores', href: '/food/clarks-cafe' },
+  { label: 'Champs Chicken', sub: 'Menu & stores', href: '/food/champs' },
+  { label: 'Cooper’s Express', sub: 'Menu & stores', href: '/food/coopers' },
+  { label: 'Clarks Rewards', sub: '10 pts per $1 · 20 pts per gallon', href: '/clarks-rewards' },
+  { label: 'Car wash', sub: 'Keep It Clean Club & gift cards', href: '/car-wash' },
+  { label: 'Beer Cave finder', sub: '47 walk-in caves', href: '/beer-cave' },
+  { label: 'Fleet & diesel', sub: 'Diesel, kerosene, fleet card', href: '/fleet' },
+  { label: 'Sports & community', sub: 'Official Fuel of the KHSAA', href: '/community' },
+  { label: 'Scholarships', sub: 'Clark Family & Rodney Clark Memorial', href: '/scholarship' },
+  { label: 'Charity', sub: 'Request a donation', href: '/charity' },
+  { label: 'Careers', sub: 'Join the Clark’s team', href: '/careers' },
+  { label: 'Our story', sub: 'One family, three generations', href: '/about-us' }
+]
+
+const AMENITY_WORDS: Array<[string, (s: (typeof allStores)[number]) => boolean]> = [
+  ['beer cave', s => !!s.amenities?.beerCave],
+  ['diesel', s => !!s.amenities?.diesel],
+  ['kerosene', s => !!s.amenities?.kerosene],
+  ['atm', s => !!s.amenities?.atm],
+  ['24 hours', s => !!s.open24],
+  ['open 24', s => !!s.open24]
+]
+
+export default function SearchOverlay({
+  open,
+  onClose
+}: {
+  open: boolean
+  onClose: () => void
+}) {
+  const [q, setQ] = useState('')
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setQ('')
+      setTimeout(() => inputRef.current?.focus(), 30)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  const hits = useMemo<Hit[]>(() => {
+    const needle = q.trim().toLowerCase()
+    if (!needle) return PAGES.slice(0, 8)
+    const out: Hit[] = []
+
+    // pages
+    for (const p of PAGES) {
+      if ((p.label + ' ' + p.sub).toLowerCase().includes(needle)) out.push(p)
+    }
+    // amenity terms -> matching stores
+    const amenity = AMENITY_WORDS.find(([w]) => needle.includes(w))
+    // stores by name/city/state/kitchen
+    for (const s of allStores) {
+      if (out.length > 14) break
+      const hay = `${s.name} ${s.city} ${s.state} ${namedKitchens(s).join(' ')}`.toLowerCase()
+      const amenityHit = amenity && amenity[1](s)
+      const restNeedle = amenity ? needle.replace(amenity[0], '').trim() : needle
+      if (
+        (amenityHit && (!restNeedle || hay.includes(restNeedle))) ||
+        (!amenity && hay.includes(needle))
+      ) {
+        out.push({
+          label: s.name,
+          sub: `${s.city}, ${(s.state || '').toUpperCase()}${amenityHit ? ` · ${amenity![0]}` : ''}`,
+          href: `/locations/${s.slug}`
+        })
+      }
+    }
+    return out.slice(0, 14)
+  }, [q])
+
+  if (!open) return null
+
+  return (
+    <div
+      className='fixed inset-0 z-modal flex items-start justify-center bg-[#060b1e]/80 p-4 pt-[12vh] backdrop-blur-sm'
+      onClick={e => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+      role='dialog'
+      aria-modal='true'
+      aria-label='Search Clark’s'
+    >
+      <div className='w-full max-w-xl overflow-hidden rounded-2xl bg-white shadow-2xl'>
+        <div className='flex items-center gap-3 border-b border-black/10 px-5'>
+          <span className='font-display text-sm tracking-[0.2em] text-brand'>
+            SEARCH
+          </span>
+          <input
+            ref={inputRef}
+            value={q}
+            onChange={e => setQ(e.target.value)}
+            placeholder='Try “beer cave lexington”, “diesel”, “pizza”, “huntington”…'
+            className='h-14 w-full bg-transparent text-base text-black outline-none placeholder:text-black/40'
+          />
+          <button
+            type='button'
+            onClick={onClose}
+            aria-label='Close search'
+            className='grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-neutral-100 text-black hover:bg-neutral-200'
+          >
+            <IconClose className='h-4 w-4' />
+          </button>
+        </div>
+        <ul className='max-h-[50vh] overflow-y-auto py-2'>
+          {hits.map(h => (
+            <li key={h.href + h.label}>
+              <Link
+                to={h.href}
+                onClick={onClose}
+                className='flex items-baseline justify-between gap-4 px-5 py-2.5 hover:bg-brand/5'
+              >
+                <span className='font-medium text-black'>{h.label}</span>
+                <span className='shrink-0 text-xs text-black/50'>{h.sub}</span>
+              </Link>
+            </li>
+          ))}
+          {hits.length === 0 && (
+            <li className='px-5 py-6 text-sm text-black/50'>
+              Nothing matched — try a town, a store name, or a food brand.
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/ClarksPNS/src/components/site/Tilt.tsx
+++ b/ClarksPNS/src/components/site/Tilt.tsx
@@ -1,0 +1,34 @@
+// Shared 3D tilt wrapper — wrap any card in <Tilt> and it leans toward
+// the cursor. Respects prefers-reduced-motion. Parent should carry
+// [perspective:...] for the strongest effect (works standalone too).
+import type { ReactNode, MouseEvent } from 'react'
+
+export default function Tilt({
+  children,
+  className = '',
+  max = 6
+}: {
+  children: ReactNode
+  className?: string
+  max?: number
+}) {
+  const onMove = (e: MouseEvent<HTMLDivElement>) => {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    const el = e.currentTarget
+    const r = el.getBoundingClientRect()
+    const x = (e.clientX - r.left) / r.width - 0.5
+    const y = (e.clientY - r.top) / r.height - 0.5
+    el.style.transform = `perspective(900px) rotateY(${x * max}deg) rotateX(${-y * max * 0.75}deg) translateZ(4px)`
+  }
+  return (
+    <div
+      onMouseMove={onMove}
+      onMouseLeave={e => {
+        e.currentTarget.style.transform = ''
+      }}
+      className={`transition-transform duration-200 [transform-style:preserve-3d] ${className}`}
+    >
+      {children}
+    </div>
+  )
+}

--- a/ClarksPNS/src/components/site/WashTunnel.tsx
+++ b/ClarksPNS/src/components/site/WashTunnel.tsx
@@ -1,0 +1,125 @@
+// Scroll-driven wash tunnel: as the section crosses the viewport a car
+// rides through FOAM, RINSE, and DRY stages. Pure CSS/SVG driven by
+// scroll progress — no libraries, reduced-motion falls back to static.
+import { useEffect, useRef, useState } from 'react'
+
+const STAGES = [
+  { label: 'FOAM', color: '#7db8ff' },
+  { label: 'RINSE', color: '#2fd06f' },
+  { label: 'DRY', color: '#ffb84d' }
+]
+
+export default function WashTunnel() {
+  const secRef = useRef<HTMLElement | null>(null)
+  const [p, setP] = useState(0) // 0..1 progress through the section
+
+  useEffect(() => {
+    const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduced) {
+      setP(0.5)
+      return
+    }
+    const onScroll = () => {
+      const el = secRef.current
+      if (!el) return
+      const r = el.getBoundingClientRect()
+      const vh = window.innerHeight
+      const total = r.height + vh
+      const done = vh - r.top
+      setP(Math.min(1, Math.max(0, done / total)))
+    }
+    onScroll()
+    window.addEventListener('scroll', onScroll, { passive: true })
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  const carX = 4 + p * 76 // percent across the tunnel
+  const stage = Math.min(2, Math.floor(p * 3))
+
+  return (
+    <section
+      ref={secRef}
+      aria-label='Ride the tunnel'
+      className='band-night brand-stripes relative overflow-hidden py-14 text-white md:py-20'
+    >
+      <div className='container mx-auto px-6 md:px-10'>
+        <h2 className='font-display text-4xl md:text-5xl'>Ride the tunnel</h2>
+        <p className='mt-2 max-w-prose text-white/80'>
+          Scroll to send one through — foam, rinse, spot-free dry.
+        </p>
+
+        <div className='relative mt-10 h-44 overflow-hidden rounded-2xl border border-white/15 bg-[#0b153a] md:h-52'>
+          {/* stage zones */}
+          <div className='absolute inset-0 grid grid-cols-3'>
+            {STAGES.map((s, i) => (
+              <div
+                key={s.label}
+                className='relative border-r border-white/10 transition-opacity duration-300 last:border-r-0'
+                style={{ opacity: stage === i ? 1 : 0.45 }}
+              >
+                <div
+                  className='absolute inset-x-0 top-0 h-1.5'
+                  style={{ background: s.color }}
+                />
+                <div
+                  className='mt-4 text-center font-display text-lg tracking-[0.3em]'
+                  style={{ color: s.color }}
+                >
+                  {s.label}
+                </div>
+                {/* stage effects */}
+                {i === 0 && (
+                  <div aria-hidden className='absolute inset-x-4 top-12 bottom-4 opacity-70'>
+                    {[...Array(9)].map((_, b) => (
+                      <span
+                        key={b}
+                        className='absolute rounded-full border border-white/60'
+                        style={{
+                          width: 8 + (b % 4) * 6,
+                          height: 8 + (b % 4) * 6,
+                          left: `${(b * 37) % 90}%`,
+                          top: `${(b * 53) % 80}%`
+                        }}
+                      />
+                    ))}
+                  </div>
+                )}
+                {i === 1 && (
+                  <div aria-hidden className='absolute inset-x-6 top-10 bottom-4 flex justify-around opacity-70'>
+                    {[...Array(6)].map((_, l) => (
+                      <span key={l} className='h-full w-0.5 rounded bg-[#7db8ff]/70' />
+                    ))}
+                  </div>
+                )}
+                {i === 2 && (
+                  <div aria-hidden className='absolute inset-x-4 top-14 bottom-6 flex flex-col justify-around opacity-60'>
+                    {[...Array(4)].map((_, l) => (
+                      <span key={l} className='h-0.5 w-full rounded bg-[#ffb84d]/70' />
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {/* the car */}
+          <div
+            className='absolute bottom-4 transition-transform duration-75'
+            style={{ left: `${carX}%` }}
+          >
+            <svg width='120' height='52' viewBox='0 0 120 52' aria-hidden>
+              <rect x='8' y='18' width='100' height='22' rx='10' fill='#eaf0ff' />
+              <path d='M28 20 C 36 6, 78 6, 90 20 Z' fill='#eaf0ff' />
+              <path d='M34 19 C 41 9, 74 9, 84 19 Z' fill='#0b153a' opacity='0.85' />
+              <circle cx='34' cy='42' r='9' fill='#0b153a' />
+              <circle cx='34' cy='42' r='4' fill='#8fa0c9' />
+              <circle cx='86' cy='42' r='9' fill='#0b153a' />
+              <circle cx='86' cy='42' r='4' fill='#8fa0c9' />
+              <rect x='98' y='24' width='9' height='6' rx='2' fill='#ffb84d' />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/ClarksPNS/src/components/site/WashWindow.tsx
+++ b/ClarksPNS/src/components/site/WashWindow.tsx
@@ -1,0 +1,46 @@
+// Wash window — reads the real 5-day rain forecast for the Tri-State
+// (Ashland home office coordinates) and suggests the best day to wash.
+// Open-Meteo, free, no key. Renders nothing if the forecast is unavailable.
+import { useEffect, useState } from 'react'
+
+const DAYS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+
+export default function WashWindow() {
+  const [line, setLine] = useState<string | null>(null)
+
+  useEffect(() => {
+    const url =
+      'https://api.open-meteo.com/v1/forecast?latitude=38.4784&longitude=-82.6379' +
+      '&daily=precipitation_probability_max&forecast_days=5&timezone=auto'
+    fetch(url)
+      .then(r => r.json())
+      .then(d => {
+        const probs: number[] = d?.daily?.precipitation_probability_max || []
+        const dates: string[] = d?.daily?.time || []
+        if (!probs.length) return
+        let best = -1
+        for (let i = 1; i < probs.length; i++) {
+          if (probs[i] <= 30) {
+            best = i
+            break
+          }
+        }
+        if (best === -1) return
+        const day = DAYS[new Date(dates[best] + 'T12:00:00').getDay()]
+        setLine(
+          `Shine weather ${day} — only a ${probs[best]}% chance of rain in the Tri-State.`
+        )
+      })
+      .catch(() => {})
+  }, [])
+
+  if (!line) return null
+
+  return (
+    <div className='bg-[#0b153a] py-2.5 text-center'>
+      <span className='font-display text-sm tracking-[0.1em] text-[#8be3ae]'>
+        {line.toUpperCase()}
+      </span>
+    </div>
+  )
+}

--- a/ClarksPNS/src/components/site/YourClarks.tsx
+++ b/ClarksPNS/src/components/site/YourClarks.tsx
@@ -43,10 +43,10 @@ export default function YourClarks() {
           className='group flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:justify-between'
         >
           <div className='flex flex-wrap items-baseline gap-x-3 gap-y-1'>
-            <span className="font-['Oswald'] text-xs uppercase tracking-wide text-white/70">
+            <span className="font-display text-xs uppercase tracking-wide text-white/70">
               Your Clark’s
             </span>
-            <span className="font-['Oswald'] text-lg font-bold md:text-xl">
+            <span className="font-display text-lg font-bold md:text-xl">
               {store.name} · {store.city}, {store.state}
             </span>
             <span className='text-sm text-white/85'>

--- a/ClarksPNS/src/components/site/YourClarks.tsx
+++ b/ClarksPNS/src/components/site/YourClarks.tsx
@@ -13,6 +13,15 @@ export default function YourClarks() {
   const [nearest, setNearest] = useState<Nearest | null>(null)
 
   useEffect(() => {
+    // A chosen "my Clark's" wins — instant, no location prompt needed.
+    const savedSlug = localStorage.getItem('clarks-my-store')
+    if (savedSlug) {
+      const s = allStores.find(st => st.slug === savedSlug)
+      if (s) {
+        setNearest({ store: s, miles: -1 })
+        return
+      }
+    }
     if (!('geolocation' in navigator)) return
     navigator.geolocation.getCurrentPosition(
       pos => {
@@ -50,7 +59,8 @@ export default function YourClarks() {
               {store.name} · {store.city}, {store.state}
             </span>
             <span className='text-sm text-white/85'>
-              {status.label} · {miles.toFixed(1)} mi away
+              {status.label}
+              {miles >= 0 ? ` · ${miles.toFixed(1)} mi away` : ''}
             </span>
           </div>
           <span className='inline-flex shrink-0 items-center gap-1 rounded-xl bg-white px-4 py-2 text-sm font-semibold text-brand transition-transform group-hover:translate-x-0.5'>

--- a/ClarksPNS/src/index.css
+++ b/ClarksPNS/src/index.css
@@ -166,3 +166,27 @@
   letter-spacing: 0.06em;
   font-size: 1.35rem;
 }
+
+/* ---------- Social cards ---------- */
+.social-card {
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+.social-card:hover {
+  transform: perspective(800px) rotateX(3deg) rotateY(-3deg) translateY(-4px);
+  box-shadow: 0 16px 40px rgba(38, 59, 149, 0.18);
+}
+.social-chip { transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1); }
+.social-card:hover .social-chip {
+  transform: rotate(-10deg) scale(1.18);
+  animation: social-wiggle 0.6s ease 0.25s;
+}
+@keyframes social-wiggle {
+  0%, 100% { transform: rotate(-10deg) scale(1.18); }
+  30% { transform: rotate(8deg) scale(1.18); }
+  60% { transform: rotate(-6deg) scale(1.18); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .social-card, .social-chip { transition: none; }
+  .social-card:hover { transform: none; }
+  .social-card:hover .social-chip { animation: none; transform: none; }
+}

--- a/ClarksPNS/src/index.css
+++ b/ClarksPNS/src/index.css
@@ -2,6 +2,10 @@
 @import '@fontsource/oswald/400.css';
 @import '@fontsource/oswald/500.css';
 @import '@fontsource/oswald/600.css';
+@import '@fontsource/oswald/700.css';
+@import '@fontsource/inter/400.css';
+@import '@fontsource/inter/500.css';
+@import '@fontsource/inter/600.css';
 /* Or: @import "@fontsource/oswald/variable.css"; */
 
 @tailwind base;
@@ -80,4 +84,21 @@
   .nav-link-active {
     @apply text-brand;
   }
+}
+/* ---------- Rodney the Rewards Ranger ---------- */
+@keyframes rodney-ride {
+  0%, 100% { transform: translateY(0) rotate(-1.2deg); }
+  50% { transform: translateY(-8px) rotate(0.6deg); }
+}
+@keyframes rodney-line {
+  0% { transform: translateX(26px); opacity: 0; }
+  30% { opacity: 1; }
+  100% { transform: translateX(-34px); opacity: 0; }
+}
+.rodney-ride { animation: rodney-ride 3.2s ease-in-out infinite; }
+.rodney-line { animation: rodney-line 1.4s ease-out infinite; }
+.rodney-line-2 { animation-delay: 0.45s; }
+.rodney-line-3 { animation-delay: 0.9s; }
+@media (prefers-reduced-motion: reduce) {
+  .rodney-ride, .rodney-line { animation: none; }
 }

--- a/ClarksPNS/src/index.css
+++ b/ClarksPNS/src/index.css
@@ -3,6 +3,7 @@
 @import '@fontsource/oswald/500.css';
 @import '@fontsource/oswald/600.css';
 @import '@fontsource/oswald/700.css';
+@import '@fontsource/bebas-neue/400.css';
 @import '@fontsource/inter/400.css';
 @import '@fontsource/inter/500.css';
 @import '@fontsource/inter/600.css';
@@ -128,3 +129,28 @@
 }
 /* Blue top rule for section cards */
 .brand-topline { box-shadow: inset 0 3px 0 0 #263B95; }
+
+/* ---------- Section modes ---------- */
+.band-night {
+  background: linear-gradient(135deg, #0b153a 0%, #16225a 45%, #263B95 100%);
+}
+/* Giant ghost display word behind section headings */
+.ghost-word {
+  position: absolute;
+  inset-inline: 0;
+  top: 0.1em;
+  z-index: 0;
+  pointer-events: none;
+  user-select: none;
+  font-family: 'Bebas Neue', Oswald, sans-serif;
+  font-size: clamp(6rem, 22vw, 18rem);
+  line-height: 0.8;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  color: transparent;
+}
+.ghost-word--light { -webkit-text-stroke: 2px rgba(255,255,255,0.14); }
+.ghost-word--blue { -webkit-text-stroke: 2px rgba(38,59,149,0.12); }
+/* Display face tuning: Bebas runs tight — give it air */
+.font-display { letter-spacing: 0.015em; }

--- a/ClarksPNS/src/index.css
+++ b/ClarksPNS/src/index.css
@@ -116,3 +116,15 @@
   animation: water-sheen 5.5s ease-in-out infinite;
 }
 @media (prefers-reduced-motion: reduce) { .water-sheen::after { animation: none; } }
+
+/* ---------- Brand fabric ---------- */
+/* White pinstripes for brand-blue bands */
+.brand-stripes {
+  background-image: repeating-linear-gradient(135deg, rgba(255,255,255,0.07) 0 2px, transparent 2px 26px);
+}
+/* Faint blue pinstripes for light sections (kills flat white) */
+.brand-stripes-light {
+  background-image: repeating-linear-gradient(135deg, rgba(38,59,149,0.05) 0 2px, transparent 2px 26px);
+}
+/* Blue top rule for section cards */
+.brand-topline { box-shadow: inset 0 3px 0 0 #263B95; }

--- a/ClarksPNS/src/index.css
+++ b/ClarksPNS/src/index.css
@@ -96,7 +96,12 @@
   30% { opacity: 1; }
   100% { transform: translateX(-34px); opacity: 0; }
 }
-.rodney-ride { animation: rodney-ride 3.2s ease-in-out infinite; }
+.rodney-ride { animation: rodney-ride 3.2s ease-in-out infinite, rodney-patrol 9s ease-in-out infinite; }
+@keyframes rodney-patrol {
+  0%, 100% { translate: 0 0; }
+  25% { translate: 26px 0; }
+  75% { translate: -26px 0; }
+}
 .rodney-line { animation: rodney-line 1.4s ease-out infinite; }
 .rodney-line-2 { animation-delay: 0.45s; }
 .rodney-line-3 { animation-delay: 0.9s; }

--- a/ClarksPNS/src/index.css
+++ b/ClarksPNS/src/index.css
@@ -154,3 +154,10 @@
 .ghost-word--blue { -webkit-text-stroke: 2px rgba(38,59,149,0.12); }
 /* Display face tuning: Bebas runs tight — give it air */
 .font-display { letter-spacing: 0.015em; }
+
+/* ---------- Top nav: brand display voice ---------- */
+.text-nav {
+  font-family: 'Bebas Neue', Oswald, sans-serif;
+  letter-spacing: 0.06em;
+  font-size: 1.35rem;
+}

--- a/ClarksPNS/src/index.css
+++ b/ClarksPNS/src/index.css
@@ -102,3 +102,17 @@
 @media (prefers-reduced-motion: reduce) {
   .rodney-ride, .rodney-line { animation: none; }
 }
+
+/* ---------- Car wash water sheen ---------- */
+@keyframes water-sheen {
+  0% { transform: translateX(-70%) skewX(-18deg); }
+  100% { transform: translateX(220%) skewX(-18deg); }
+}
+.water-sheen::after {
+  content: '';
+  position: absolute;
+  top: 0; bottom: 0; width: 34%;
+  background: linear-gradient(90deg, transparent, rgba(0, 132, 255, 0.10), rgba(255, 255, 255, 0.16), transparent);
+  animation: water-sheen 5.5s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) { .water-sheen::after { animation: none; } }

--- a/ClarksPNS/src/lib/stores.ts
+++ b/ClarksPNS/src/lib/stores.ts
@@ -171,3 +171,17 @@ export function storeJsonLd(store: Store, siteUrl = 'https://www.myclarkspns.com
     ...(amenity.length ? { amenityFeature: amenity } : {})
   }
 }
+
+/** Cloudinary-composed 1200x630 share card: the store's real hero photo
+ *  with its name overlaid. Used for og:image on store pages. */
+export function ogImageUrl(store: Store): string | undefined {
+  const enc = (s: string) =>
+    encodeURIComponent(s.replace(/[,\/]/g, ' ')).replace(/%2C/g, '')
+  return (
+    'https://res.cloudinary.com/yzpytwu5/image/upload/' +
+    'w_1200,h_630,c_fill,g_auto,q_auto:good/' +
+    `co_white,g_south_west,x_60,y_120,l_text:Arial_64_bold:${enc(store.name)}/` +
+    `co_rgb:BFD5FF,g_south_west,x_60,y_70,l_text:Arial_36:${enc(`${store.city} ${(store.state || '').toUpperCase()} · Clark's Pump-N-Shop`)}/` +
+    `v1/clarks/stores/${store.slug}/hero.jpg`
+  )
+}

--- a/ClarksPNS/src/lib/track.ts
+++ b/ClarksPNS/src/lib/track.ts
@@ -1,0 +1,10 @@
+// Conversion tracking — named events into Vercel Analytics.
+import { track as vercelTrack } from '@vercel/analytics'
+
+export function track(event: string, data?: Record<string, string | number>) {
+  try {
+    vercelTrack(event, data)
+  } catch {
+    // analytics must never break the site
+  }
+}

--- a/ClarksPNS/src/pages/About.tsx
+++ b/ClarksPNS/src/pages/About.tsx
@@ -129,7 +129,7 @@ export default function About () {
                 <p className='uppercase tracking-widest text-white/80 text-xs md:text-sm'>
                   About
                 </p>
-                <h1 className="font-['Oswald'] text-4xl md:text-5xl font-bold leading-tight">
+                <h1 className="font-display text-4xl md:text-5xl font-bold leading-tight">
                   Family owned. Community focused. Since 1976.
                 </h1>
                 <p className='mt-4 text-white/90 text-base md:text-lg'>
@@ -179,7 +179,7 @@ export default function About () {
       <section id='story' className='py-14 md:py-20 bg-white'>
         <div className='container mx-auto px-6 md:px-10 grid lg:grid-cols-12 gap-10'>
           <div className='lg:col-span-7'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               Our Story
             </h2>
             <div className='prose prose-neutral max-w-none mt-4 text-black/80'>
@@ -213,7 +213,7 @@ export default function About () {
           {/* Founders panel */}
           <div className='lg:col-span-5'>
             <div className='rounded-2xl border border-black/10 bg-brand/5 p-6'>
-              <h3 className="font-['Oswald'] text-xl font-bold text-black">
+              <h3 className="font-display text-xl font-bold text-black">
                 Family Owned &amp; Operated
               </h3>
               <ul className='mt-4 space-y-3'>
@@ -243,10 +243,10 @@ export default function About () {
       <section id='timeline' className='py-14 md:py-20 bg-neutral-50 border-y border-black/10'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+            <p className="font-display tracking-wide text-xs uppercase text-brand">
               Our history
             </p>
-            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">
               One family. Three generations.
             </h2>
           </div>
@@ -262,10 +262,10 @@ export default function About () {
                 </span>
                 <div className='grid grid-cols-1 items-start gap-6 md:grid-cols-12'>
                   <div className={t.img ? 'md:col-span-7' : 'md:col-span-12'}>
-                    <p className="font-['Oswald'] text-2xl font-bold text-brand leading-none">
+                    <p className="font-display text-2xl font-bold text-brand leading-none">
                       {t.year}
                     </p>
-                    <h3 className="mt-1 font-['Oswald'] text-xl md:text-2xl font-bold text-black">
+                    <h3 className="mt-1 font-display text-xl md:text-2xl font-bold text-black">
                       {t.title}
                     </h3>
                     <p className='mt-2 max-w-prose text-black/70'>{t.desc}</p>
@@ -296,7 +296,7 @@ export default function About () {
       <section id='footprint' className='py-14 md:py-20 bg-neutral-50'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               Where we are
             </h2>
             <p className='mt-2 text-black/70'>
@@ -331,7 +331,7 @@ export default function About () {
       <section id='leadership' className='py-14 md:py-20 bg-white'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               Leadership &amp; Management
             </h2>
             <p className='mt-2 text-black/70'>
@@ -385,7 +385,7 @@ export default function About () {
         <div className='container mx-auto px-6 md:px-10 grid lg:grid-cols-12 gap-10 items-center'>
           {/* Left copy */}
           <div className='lg:col-span-7'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold">
+            <h2 className="font-display text-3xl md:text-4xl font-bold">
               Careers at Clark’s
             </h2>
             <p className='mt-3 text-white/90 max-w-prose'>
@@ -444,7 +444,7 @@ export default function About () {
       <section id='community' className='py-14 md:py-20 bg-white'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               Community &amp; Giving
             </h2>
             <p className='mt-2 text-black/70'>
@@ -509,7 +509,7 @@ export default function About () {
 function StatCard ({ k, v }: { k: string; v: string }) {
   return (
     <li className='rounded-2xl border border-white/15 bg-white/10 px-5 py-6'>
-      <p className="font-['Oswald'] text-3xl font-bold text-white leading-none">
+      <p className="font-display text-3xl font-bold text-white leading-none">
         {k}
       </p>
       <p className='mt-1 text-white/75'>{v}</p>

--- a/ClarksPNS/src/pages/About.tsx
+++ b/ClarksPNS/src/pages/About.tsx
@@ -163,7 +163,7 @@ export default function About () {
       {/* QUICK STATS — bring color into a light section */}
       <section
         aria-label='Fast facts'
-        className='bg-neutral-50 py-10 md:py-14 border-y border-black/10'
+        className='bg-brand brand-stripes py-10 md:py-14'
       >
         <div className='container mx-auto px-6 md:px-10'>
           <ul className='grid grid-cols-2 md:grid-cols-4 gap-4'>
@@ -508,11 +508,11 @@ export default function About () {
 
 function StatCard ({ k, v }: { k: string; v: string }) {
   return (
-    <li className='rounded-2xl border border-black/10 bg-white px-5 py-6'>
-      <p className="font-['Oswald'] text-3xl font-bold text-brand leading-none">
+    <li className='rounded-2xl border border-white/15 bg-white/10 px-5 py-6'>
+      <p className="font-['Oswald'] text-3xl font-bold text-white leading-none">
         {k}
       </p>
-      <p className='mt-1 text-black/70'>{v}</p>
+      <p className='mt-1 text-white/75'>{v}</p>
     </li>
   )
 }

--- a/ClarksPNS/src/pages/About.tsx
+++ b/ClarksPNS/src/pages/About.tsx
@@ -64,6 +64,11 @@ const TIMELINE: Array<{
   imgAlt?: string
 }> = [
   {
+    year: '1970',
+    title: 'A Gulf Oil distributorship',
+    desc: 'John W. Clark enters the fuel business as a distributor for Gulf Oil — the foundation everything since is built on.'
+  },
+  {
     year: '1976',
     title: 'One store in Westwood',
     desc: 'John W. Clark opens a single convenience store in his hometown of Westwood, Kentucky.',
@@ -242,7 +247,7 @@ export default function About () {
               Our history
             </p>
             <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
-              Fifty years, one family.
+              One family. Three generations.
             </h2>
           </div>
 

--- a/ClarksPNS/src/pages/BeerCave.tsx
+++ b/ClarksPNS/src/pages/BeerCave.tsx
@@ -2,6 +2,7 @@
 // amenity data the store pages use.
 import { Link } from 'react-router-dom'
 import { SEO } from '@/lib/seo'
+import { IconSnow } from '@/components/site/Icons'
 import { allStores, openNow, type Store } from '@/lib/stores'
 
 const CAVE_STORES = allStores.filter(s => s.amenities?.beerCave)
@@ -103,7 +104,7 @@ function CaveCard({ store }: { store: Store }) {
           {store.name}
         </div>
         <span className='shrink-0 rounded-full bg-[#eaf3ff] px-2.5 py-1 text-xs font-semibold text-brand'>
-          ❄ Beer Cave
+          <IconSnow className='inline h-3.5 w-3.5 -mt-0.5 mr-1' /> Beer Cave
         </span>
       </div>
       <div className='mt-1 text-sm text-black/70'>

--- a/ClarksPNS/src/pages/BeerCave.tsx
+++ b/ClarksPNS/src/pages/BeerCave.tsx
@@ -42,11 +42,12 @@ export default function BeerCave() {
           aria-hidden
           className='pointer-events-none absolute -top-24 left-1/2 h-72 w-[130%] -translate-x-1/2 rounded-[100%] bg-white/10 blur-3xl'
         />
+        <div aria-hidden className='ghost-word ghost-word--light text-center'>ICE COLD</div>
         <div className='container relative z-[1] mx-auto px-6 py-20 text-white md:px-10 md:py-28'>
-          <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-white/70">
+          <div className="font-display text-xs uppercase tracking-[0.3em] text-white/70">
             The Beer Cave
           </div>
-          <h1 className="mt-2 font-['Oswald'] text-5xl font-bold leading-none md:text-7xl">
+          <h1 className="mt-2 font-display text-5xl font-bold leading-none md:text-7xl">
             Ice cold.
             <br />
             Walk in.
@@ -70,7 +71,7 @@ export default function BeerCave() {
       <section id='find' className='container mx-auto px-6 py-12 md:px-10'>
         {BY_STATE.filter(g => g.stores.length).map(g => (
           <div key={g.state} className='mb-10'>
-            <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+            <h2 className="font-display text-3xl font-bold text-black md:text-4xl">
               {g.label}
               <span className='ml-3 align-middle text-base font-normal text-black/50'>
                 {g.stores.length} cave{g.stores.length === 1 ? '' : 's'}
@@ -109,7 +110,7 @@ function CaveCard({ store }: { store: Store }) {
       className='group rounded-2xl border border-black/10 brand-topline bg-white p-5 shadow-soft transition-[box-shadow,transform] duration-200 hover:shadow-md'
     >
       <div className='flex items-center justify-between gap-3'>
-        <div className="font-['Oswald'] text-lg font-bold text-black group-hover:text-brand">
+        <div className="font-display text-lg font-bold text-black group-hover:text-brand">
           {store.name}
         </div>
         <span className='shrink-0 rounded-full bg-[#eaf3ff] px-2.5 py-1 text-xs font-semibold text-brand'>

--- a/ClarksPNS/src/pages/BeerCave.tsx
+++ b/ClarksPNS/src/pages/BeerCave.tsx
@@ -97,7 +97,16 @@ function CaveCard({ store }: { store: Store }) {
   return (
     <Link
       to={`/locations/${store.slug}`}
-      className='group rounded-2xl border border-black/10 bg-white p-5 shadow-soft transition-shadow hover:shadow-md'
+      onMouseMove={e => {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+        const el = e.currentTarget
+        const r = el.getBoundingClientRect()
+        const x = (e.clientX - r.left) / r.width - 0.5
+        const y = (e.clientY - r.top) / r.height - 0.5
+        el.style.transform = `perspective(900px) rotateY(${x * 5}deg) rotateX(${-y * 4}deg)`
+      }}
+      onMouseLeave={e => { e.currentTarget.style.transform = '' }}
+      className='group rounded-2xl border border-black/10 brand-topline bg-white p-5 shadow-soft transition-[box-shadow,transform] duration-200 hover:shadow-md'
     >
       <div className='flex items-center justify-between gap-3'>
         <div className="font-['Oswald'] text-lg font-bold text-black group-hover:text-brand">

--- a/ClarksPNS/src/pages/CarWash.tsx
+++ b/ClarksPNS/src/pages/CarWash.tsx
@@ -1,5 +1,5 @@
-// src/pages/CarWash.tsx
-import React from 'react'
+// Clarks Car Wash — night-mode rebuild. Real wash photos, the Keep It
+// Clean Club, 3D gift cards, and zero flat-white sections.
 import { Link } from 'react-router-dom'
 import { IconShine, IconFoam, IconFast, IconDrop } from '@/components/site/Icons'
 import Tilt from '@/components/site/Tilt'
@@ -8,370 +8,199 @@ import img1 from '@/assets/images/carwashphotos/DJI_0019.jpg'
 import img2 from '@/assets/images/carwashphotos/DSC02583.jpg'
 import img3 from '@/assets/images/carwashphotos/DSC03955.jpg'
 import img4 from '@/assets/images/carwashphotos/DSC04072.jpg'
+import whiteLogo from '@/assets/images/Clarks PNS Logo Updated all white.png'
+
+const JOIN = 'https://checkout.myclarkspns.com/checkout/buy/33394'
+const LOGIN = 'https://checkout.myclarkspns.com/account/auth/login'
 
 export default function CarWash () {
   return (
     <main className='w-full overflow-x-clip bg-white'>
-      {/* === Hero === */}
-      <section
-        aria-label='Clarks Car Wash'
-        className='
-          relative isolate z-0 w-full
-          -mt-[16px] md:-mt-[20px]
-          bg-gradient-to-br from-white via-white to-neutral-50
-        '
-      >
-        {/* Decorative background */}
-        <div
+      {/* === Night hero over a real wash === */}
+      <section className='relative isolate -mt-[16px] overflow-hidden md:-mt-[20px]'>
+        <img
+          src={img4}
+          alt=''
           aria-hidden
-          className='pointer-events-none absolute inset-0 opacity-[0.08]'
-          style={{
-            background:
-              'repeating-linear-gradient(135deg, #0ea5e9 0 2px, transparent 2px 24px)'
-          }}
+          className='absolute inset-0 h-full w-full object-cover'
         />
-        <div
-          aria-hidden
-          className='pointer-events-none absolute -inset-40 rounded-[64px] blur-3xl bg-brand/10'
-        />
+        <div className='absolute inset-0 band-night opacity-[0.86]' />
         <div aria-hidden className='water-sheen pointer-events-none absolute inset-0' />
+        <div aria-hidden className='ghost-word ghost-word--light text-center'>WASH</div>
 
-        <div className='relative z-[1] pt-[16px] md:pt-[20px]'>
-          <div className='container mx-auto px-6 md:px-10'>
-            {/* ↓ reduced height here */}
-            <div className='flex min-h-[40vh] md:min-h-[50vh] items-center'>
-              <div className='inline-flex flex-col gap-4 md:gap-6 max-w-[760px]'>
-                <h1 className="font-['Oswald'] font-bold text-black text-4xl md:text-6xl leading-tight">
-                  Clarks Car Wash
-                </h1>
-                <p className='text-black/70 text-lg md:text-2xl max-w-prose'>
-                  Fast lanes. Gentle clean. Showroom shine—every time.
-                </p>
-
-                <div className='flex flex-col sm:flex-row gap-3 sm:gap-4'>
-                  <a
-                    href='#club'
-                    className='inline-flex items-center justify-center rounded-2xl px-6 py-3 text-white bg-brand hover:bg-brand/90 transition-all shadow-lg shadow-brand/20 text-base md:text-lg'
-                  >
-                    Join the Keep It Clean Club
-                  </a>
-                  <Link
-                    to='/locations?amenity=carwash'
-                    className='inline-flex items-center justify-center rounded-2xl px-6 py-3 text-black/90 bg-neutral-100 hover:bg-neutral-200 transition-all text-base md:text-lg'
-                  >
-                    Find a Car Wash Near You
-                  </Link>
-                </div>
-              </div>
-            </div>
+        <div className='container relative z-[1] mx-auto px-6 py-24 text-white md:px-10 md:py-32'>
+          <div className='font-display text-xs uppercase tracking-[0.3em] text-white/70'>
+            Clarks Car Wash
           </div>
-
-          <div className='h-10 md:h-14 w-full bg-gradient-to-b from-transparent to-white' />
+          <h1 className='mt-2 font-display text-5xl leading-none md:text-8xl'>
+            Roll in dusty.
+            <br />
+            Roll out showroom.
+          </h1>
+          <p className='mt-5 max-w-prose text-lg text-white/90 md:text-xl'>
+            Fast lanes, gentle materials, spot-free shine — at Clark’s washes
+            across the Tri-State.
+          </p>
+          <div className='mt-8 flex flex-col gap-3 sm:flex-row'>
+            <a
+              href='#club'
+              className='inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 text-base font-semibold text-brand transition-transform hover:-translate-y-0.5 md:text-lg'
+            >
+              Join the Keep It Clean Club
+            </a>
+            <Link
+              to='/locations?amenity=carwash'
+              className='inline-flex items-center justify-center rounded-2xl border border-white/40 px-6 py-3 text-base font-medium text-white transition-colors hover:bg-white/10 md:text-lg'
+            >
+              Find a wash near you
+            </Link>
+          </div>
         </div>
       </section>
-      {/* === Keep It Clean Club (moved here, right after hero) === */}
+
+      {/* === Keep It Clean Club — brand band === */}
       <section
         id='club'
         aria-label='Keep It Clean Club'
-        className='py-12 md:py-20 bg-surface-alt brand-stripes-light border-y border-black/10'
+        className='relative overflow-hidden bg-brand brand-stripes py-14 text-white md:py-20'
       >
-        <div className='container mx-auto px-6 md:px-10'>
-          <div className='grid grid-cols-1 lg:grid-cols-2 items-center gap-10'>
-            <div className='order-2 lg:order-1'>
-              <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+        <img
+          src={whiteLogo}
+          alt=''
+          aria-hidden
+          className='pointer-events-none absolute -right-16 -top-10 w-[420px] rotate-[-8deg] opacity-[0.06]'
+        />
+        <div className='container relative mx-auto px-6 md:px-10'>
+          <div className='grid grid-cols-1 items-center gap-10 lg:grid-cols-2'>
+            <div>
+              <h2 className='font-display text-4xl md:text-5xl'>
                 Keep It Clean Club
               </h2>
-              <p className='mt-3 text-black/70 text-base md:text-lg'>
-                Go unlimited, manage your plan, and keep that glossy
-                finish—always.
+              <p className='mt-3 max-w-prose text-lg text-white/85'>
+                Unlimited washes, one flat month — manage everything online
+                and keep that glossy finish always.
               </p>
-
-              <div className='mt-6 flex flex-col sm:flex-row items-start sm:items-center gap-4'>
+              <div className='mt-6 flex flex-col items-start gap-4 sm:flex-row sm:items-center'>
                 <a
-                  href='https://checkout.myclarkspns.com/checkout/buy/33394'
+                  href={JOIN}
                   target='_blank'
                   rel='noopener noreferrer'
-                  className='inline-flex items-center justify-center rounded-2xl px-6 py-3 text-white bg-brand hover:bg-brand/90 transition-all shadow-lg shadow-brand/25'
+                  className='inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 font-semibold text-brand transition-transform hover:-translate-y-0.5'
                 >
                   Sign up
                 </a>
                 <a
-                  href='https://checkout.myclarkspns.com/account/auth/login'
+                  href={LOGIN}
                   target='_blank'
                   rel='noopener noreferrer'
-                  className='inline-flex items-center justify-center rounded-2xl px-6 py-3 bg-white border border-black/10 hover:bg-neutral-100 text-black/90 transition-all'
+                  className='inline-flex items-center justify-center rounded-2xl border border-white/40 px-6 py-3 font-medium text-white transition-colors hover:bg-white/10'
                 >
                   Log in
                 </a>
               </div>
-
-              <ul className='mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-black/70'>
-                <li className='flex items-start gap-2'>
-                  <span className='mt-1 inline-block h-2 w-2 rounded-full bg-brand' />
-                  Wash as often as you like
-                </li>
-                <li className='flex items-start gap-2'>
-                  <span className='mt-1 inline-block h-2 w-2 rounded-full bg-brand' />
-                  Manage plan online
-                </li>
-                <li className='flex items-start gap-2'>
-                  <span className='mt-1 inline-block h-2 w-2 rounded-full bg-brand' />
-                  Fast lane access
-                </li>
-                <li className='flex items-start gap-2'>
-                  <span className='mt-1 inline-block h-2 w-2 rounded-full bg-brand' />
-                  Cancel anytime
-                </li>
+              <ul className='mt-6 grid grid-cols-1 gap-3 text-sm text-white/85 sm:grid-cols-2'>
+                {['Wash as often as you like', 'Manage plan online', 'Fast lane access', 'Cancel anytime'].map(f => (
+                  <li key={f} className='flex items-start gap-2'>
+                    <span className='mt-1 inline-block h-2 w-2 rounded-full bg-white' />
+                    {f}
+                  </li>
+                ))}
               </ul>
             </div>
-
-            <div className='order-1 lg:order-2'>
-  <div className='relative mx-auto w-full max-w-[520px]'>
-    <div className='grid grid-cols-2 gap-4'>
-      {[img1, img2, img3, img4].map((src, i) => (
-        <div
-          key={i}
-          className='overflow-hidden rounded-2xl border border-black/10 h-32'
-        >
-          <img
-            src={src}
-            alt={`Car wash photo ${i + 1}`}
-            className='h-full w-full object-cover'
-          />
-        </div>
-      ))}
-    </div>
-    <div className='pointer-events-none absolute -inset-2 -z-10 rounded-[32px] bg-brand/10 blur-xl' />
-  </div>
-</div>
-
+            <div className='grid grid-cols-2 gap-4 [perspective:1200px]'>
+              {[img1, img2, img3, img4].map((src, i) => (
+                <Tilt key={i} max={8}>
+                  <div className='overflow-hidden rounded-2xl border border-white/20 shadow-lg'>
+                    <img
+                      src={src}
+                      alt={`Clark’s car wash ${i + 1}`}
+                      loading='lazy'
+                      className='h-36 w-full object-cover md:h-40'
+                    />
+                  </div>
+                </Tilt>
+              ))}
+            </div>
           </div>
         </div>
       </section>
-      {/* === Benefits === */}
-      <section aria-label='Car Wash Benefits' className='py-12 md:py-20 bg-white'>
-        <div className='container mx-auto px-6 md:px-10'>
-          <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
-              Why wash at Clarks
-            </h2>
-            <p className='mt-2 text-black/70 text-base md:text-lg'>
-              Pro formulas, soft-touch materials, and a spotless finish—fast.
-            </p>
-          </div>
 
-          <div className='mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6'>
+      {/* === Benefits — paper mode === */}
+      <section aria-label='Car Wash Benefits' className='relative bg-surface-alt brand-stripes-light py-14 md:py-20'>
+        <div aria-hidden className='ghost-word ghost-word--blue text-center'>SHINE</div>
+        <div className='container relative mx-auto px-6 md:px-10'>
+          <h2 className='font-display text-4xl text-black md:text-5xl'>
+            Why wash at Clarks
+          </h2>
+          <p className='mt-2 max-w-prose text-black/70'>
+            Pro formulas, soft-touch materials, and a spotless finish — fast.
+          </p>
+          <div className='mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4'>
             {BENEFITS.map(b => (
               <Tilt key={b.title}>
-              <article
-                className='rounded-2xl border border-black/10 brand-topline p-6 hover:shadow-md transition-shadow bg-white'
-              >
-                <div className='mb-4'>
-                  <span
-                    aria-hidden
-                    className='inline-flex h-12 w-12 items-center justify-center rounded-xl bg-brand/10'
-                  >
+                <article className='rounded-2xl border border-black/10 brand-topline bg-white p-6'>
+                  <span className='inline-flex h-12 w-12 items-center justify-center rounded-xl bg-brand/10'>
                     <b.icon className='h-6 w-6 text-brand' />
                   </span>
-                </div>
-                <h3 className="font-['Oswald'] text-xl font-bold text-black">{b.title}</h3>
-                <p className='mt-2 text-black/70 text-sm leading-relaxed'>{b.desc}</p>
-              </article>
+                  <h3 className='mt-4 font-display text-2xl text-black'>{b.title}</h3>
+                  <p className='mt-2 text-sm leading-relaxed text-black/70'>{b.desc}</p>
+                </article>
               </Tilt>
             ))}
           </div>
         </div>
       </section>
 
-      {/* === How it works === */}
-      <section aria-label='How it works' className='py-12 md:py-20 bg-neutral-50 border-y border-black/10'>
+      {/* === How it works — night mode === */}
+      <section aria-label='How it works' className='band-night brand-stripes py-14 text-white md:py-20'>
         <div className='container mx-auto px-6 md:px-10'>
-          <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
-              How it works
-            </h2>
-            <p className='mt-2 text-black/70 text-base md:text-lg'>
-              Three steps between you and a showroom shine.
-            </p>
-          </div>
-          <ol className='mt-10 grid grid-cols-1 md:grid-cols-3 gap-6'>
+          <h2 className='font-display text-4xl md:text-5xl'>Three steps to shine</h2>
+          <ol className='mt-10 grid grid-cols-1 gap-6 md:grid-cols-3'>
             {STEPS.map((s, i) => (
-              <li
-                key={s.title}
-                className='relative rounded-2xl border border-black/10 bg-white p-6'
-              >
-                <span className="font-['Oswald'] absolute -top-4 left-6 grid h-9 w-9 place-items-center rounded-xl bg-brand text-lg font-bold text-white shadow-md">
+              <li key={s.title} className='relative rounded-2xl border border-white/15 bg-white/5 p-6'>
+                <span className='absolute -top-4 left-6 grid h-9 w-9 place-items-center rounded-xl bg-white font-display text-lg text-brand shadow-md'>
                   {i + 1}
                 </span>
-                <h3 className="mt-2 font-['Oswald'] text-xl font-bold text-black">
-                  {s.title}
-                </h3>
-                <p className='mt-2 text-sm leading-relaxed text-black/70'>{s.desc}</p>
+                <h3 className='mt-2 font-display text-2xl'>{s.title}</h3>
+                <p className='mt-2 text-sm leading-relaxed text-white/75'>{s.desc}</p>
               </li>
             ))}
           </ol>
         </div>
       </section>
 
-      
-      {/* === Packages / Pricing === */}
-      {/* <section
-        id='packages'
-        aria-label='Wash Packages'
-        className='py-12 md:py-20 bg-neutral-50'
-      >
-        <div className='container mx-auto px-6 md:px-10'>
-          <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
-              Pick your perfect wash
-            </h2>
-            <p className='mt-2 text-black/70 text-base md:text-lg'>
-              Pay per wash or go unlimited with a monthly plan.
-            </p>
-          </div>
-
-          <div className='mt-10 grid grid-cols-1 md:grid-cols-3 gap-6'>
-            {PACKAGES.map(p => (
-              <article
-                key={p.name}
-                className={`relative rounded-2xl border p-6 bg-white ${
-                  p.featured
-                    ? 'border-brand ring-2 ring-brand/25 shadow-xl'
-                    : 'border-black/10 hover:shadow-md transition-shadow'
-                }`}
-              >
-                {p.featured && (
-                  <div className='absolute -top-3 right-4 rounded-lg bg-brand text-white text-xs font-semibold px-3 py-1 shadow-sm'>
-                    Most Popular
-                  </div>
-                )}
-                <h3 className="font-['Oswald'] text-2xl font-bold text-black">
-                  {p.name}
-                </h3>
-                <p className='mt-1 text-black/60 text-sm'>{p.tagline}</p>
-                <div className='mt-4 flex items-baseline gap-2'>
-                  <div className='text-3xl font-bold text-black'>
-                    ${p.price}
-                  </div>
-                  <div className='text-black/60 text-sm'>{p.freq}</div>
-                </div>
-
-                <ul className='mt-4 space-y-2 text-sm text-black/80'>
-                  {p.features.map(f => (
-                    <li key={f} className='flex gap-2'>
-                      <span className='mt-1 inline-block h-2 w-2 rounded-full bg-brand' />
-                      {f}
-                    </li>
-                  ))}
-                </ul>
-
-                <div className='mt-6 flex flex-col sm:flex-row gap-3'>
-                  <a
-                    href='#join'
-                    className='inline-flex items-center justify-center rounded-2xl px-5 py-3 text-white bg-brand hover:bg-brand/90 transition-all'
-                  >
-                    {p.cta}
-                  </a>
-                </div>
-              </article>
-            ))}
-          </div>
-
-          <p className='mt-6 text-xs text-black/60'>
-            * Unlimited plans billed monthly. Manage anytime in the app.
+      {/* === Gift cards — 3D plastic === */}
+      <section id='giftcards' aria-label='Car Wash Gift Cards' className='relative overflow-hidden bg-surface-alt brand-stripes-light py-14 md:py-20'>
+        <div aria-hidden className='ghost-word ghost-word--blue text-center'>GIFT</div>
+        <div className='container relative mx-auto px-6 md:px-10'>
+          <h2 className='font-display text-4xl text-black md:text-5xl'>Give the shine</h2>
+          <p className='mt-2 max-w-prose text-black/70'>
+            Digital gift cards, delivered instantly through myclarkspns.com.
           </p>
-        </div>
-      </section> */}
-
-
-
-      {/* === NEW: Gift Cards === */}
-      <section
-        id='giftcards'
-        aria-label='Car Wash Gift Cards'
-        className='py-12 md:py-20 bg-white'
-      >
-        <div className='container mx-auto px-6 md:px-10'>
-          <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
-              Gift cards
-            </h2>
-            <p className='mt-2 text-black/70 text-base md:text-lg'>
-              Give the gift of a showroom shine. Digital delivery through
-              myclarkspns.com.
-            </p>
+          <div className='mt-10 grid max-w-3xl grid-cols-1 gap-8 sm:grid-cols-2 [perspective:1400px]'>
+            <GiftCard value='$50' note='Great for a few quick washes.' href='https://checkout.myclarkspns.com/checkout/buy/33396' />
+            <GiftCard value='$150' note='A whole season of shine.' href='https://checkout.myclarkspns.com/checkout/buy/33397' />
           </div>
-
-          <div className='mt-8 grid grid-cols-1 sm:grid-cols-2 gap-6'>
-            <article className='rounded-2xl border border-black/10 bg-white p-6 hover:shadow-md transition-shadow'>
-              <h3 className="font-['Oswald'] text-xl font-bold text-black">
-                $50 Gift Card
-              </h3>
-              <p className='mt-2 text-sm text-black/70'>
-                Great for a few quick washes.
-              </p>
-              <a
-                href='https://checkout.myclarkspns.com/checkout/buy/33396'
-                target='_blank'
-                rel='noopener noreferrer'
-                className='mt-4 inline-flex items-center justify-center rounded-2xl px-5 py-3 text-white bg-brand hover:bg-brand/90 transition-all'
-              >
-                Buy $50 Gift Card
-              </a>
-            </article>
-
-            <article className='rounded-2xl border border-black/10 bg-white p-6 hover:shadow-md transition-shadow'>
-              <h3 className="font-['Oswald'] text-xl font-bold text-black">
-                $150 Gift Card
-              </h3>
-              <p className='mt-2 text-sm text-black/70'>
-                Perfect for gifting a season of shine.
-              </p>
-              <a
-                href='https://checkout.myclarkspns.com/checkout/buy/33397'
-                target='_blank'
-                rel='noopener noreferrer'
-                className='mt-4 inline-flex items-center justify-center rounded-2xl px-5 py-3 text-white bg-brand hover:bg-brand/90 transition-all'
-              >
-                Buy $150 Gift Card
-              </a>
-            </article>
-          </div>
-
           <p className='mt-6 text-xs text-black/60'>
-            Gift cards are redeemable at participating locations and online
-            where available.
+            Gift cards are redeemable at participating locations and online where available.
           </p>
         </div>
       </section>
 
       {/* === FAQ === */}
-      <section aria-label='Car Wash FAQ' className='py-12 md:py-20 bg-white'>
+      <section aria-label='Car Wash FAQ' className='bg-white py-14 md:py-20'>
         <div className='container mx-auto px-6 md:px-10'>
-          <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
-              Frequently asked questions
-            </h2>
-            <p className='mt-2 text-black/70 text-base md:text-lg'>
-              Quick answers about washes, memberships, and locations.
-            </p>
-          </div>
-
-          <div className='mt-8 grid grid-cols-1 md:grid-cols-2 gap-6'>
+          <h2 className='font-display text-4xl text-black md:text-5xl'>Quick answers</h2>
+          <div className='mt-8 grid grid-cols-1 gap-6 md:grid-cols-2'>
             {FAQS.map(f => (
-              <details
-                key={f.q}
-                className='group rounded-2xl bg-white p-6 border border-black/10 open:shadow-md'
-              >
-                <summary className="cursor-pointer list-none font-['Oswald'] text-lg font-bold text-black flex items-center justify-between">
+              <details key={f.q} className='group rounded-2xl border border-black/10 brand-topline bg-white p-6 open:shadow-md'>
+                <summary className='flex cursor-pointer list-none items-center justify-between font-display text-xl text-black'>
                   {f.q}
-                  <span className='ml-4 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-neutral-100 group-open:rotate-45 transition-transform'>
+                  <span className='ml-4 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-neutral-100 transition-transform group-open:rotate-45'>
                     +
                   </span>
                 </summary>
-                <p className='mt-3 text-black/70 text-sm leading-relaxed'>
-                  {f.a}
-                </p>
+                <p className='mt-3 text-sm leading-relaxed text-black/70'>{f.a}</p>
               </details>
             ))}
           </div>
@@ -381,94 +210,56 @@ export default function CarWash () {
   )
 }
 
+/** A branded plastic gift card in 3D. */
+function GiftCard ({ value, note, href }: { value: string; note: string; href: string }) {
+  return (
+    <div>
+      <Tilt max={10}>
+        <div className='band-night brand-stripes relative aspect-[1.586] overflow-hidden rounded-2xl shadow-xl'>
+          <img
+            src={whiteLogo}
+            alt='Clark’s Pump-N-Shop'
+            className='absolute left-5 top-5 h-9 w-auto'
+          />
+          <div className='absolute bottom-5 left-5 font-display text-5xl text-white'>
+            {value}
+          </div>
+          <div className='absolute bottom-6 right-5 text-right text-[0.6rem] uppercase tracking-[0.25em] text-white/60'>
+            Car wash
+            <br />
+            gift card
+          </div>
+          <div aria-hidden className='absolute -right-10 top-1/2 h-40 w-40 -translate-y-1/2 rounded-full bg-[#0084FF]/25 blur-2xl' />
+        </div>
+      </Tilt>
+      <p className='mt-3 text-sm text-black/70'>{note}</p>
+      <a
+        href={href}
+        target='_blank'
+        rel='noopener noreferrer'
+        className='mt-2 inline-flex items-center justify-center rounded-2xl bg-brand px-5 py-2.5 text-white transition-colors hover:bg-brand/90'
+      >
+        Buy the {value} card
+      </a>
+    </div>
+  )
+}
+
 const BENEFITS = [
-  {
-    icon: IconShine,
-    title: 'Showroom shine',
-    desc: 'Poly sealant + spot-free rinse for a glossy, protected finish.'
-  },
-  {
-    icon: IconFoam,
-    title: 'Gentle clean',
-    desc: 'Soft-touch materials and pH-balanced soaps safe for clear coat.'
-  },
-  {
-    icon: IconFast,
-    title: 'Fast lanes',
-    desc: 'In-and-out convenience designed for busy mornings and quick stops.'
-  },
-  {
-    icon: IconDrop,
-    title: 'Spot-free dry',
-    desc: 'Filtered water + high-velocity air for a streak-free result.'
-  }
+  { icon: IconShine, title: 'Showroom shine', desc: 'Poly sealant + spot-free rinse for a glossy, protected finish.' },
+  { icon: IconFoam, title: 'Gentle clean', desc: 'Soft-touch materials and pH-balanced soaps safe for clear coat.' },
+  { icon: IconFast, title: 'Fast lanes', desc: 'In-and-out convenience designed for busy mornings and quick stops.' },
+  { icon: IconDrop, title: 'Spot-free dry', desc: 'Filtered water + high-velocity air for a streak-free result.' }
 ]
 
-const PACKAGES = [
-  {
-    name: 'Basic',
-    tagline: 'Quick clean & dry',
-    price: 8,
-    freq: 'per wash',
-    features: ['Foam bath', 'Soft-touch wash', 'Spot-free rinse', 'Power dry'],
-    cta: 'Get Basic'
-  },
-  {
-    name: 'Premium',
-    tagline: 'Shine + protect',
-    price: 14,
-    freq: 'per wash',
-    features: [
-      'Everything in Basic',
-      'Triple-foam polish',
-      'Wheel clean',
-      'Clear coat protectant'
-    ],
-    cta: 'Choose Premium',
-    featured: true
-  },
-  {
-    name: 'Ultimate',
-    tagline: 'Maximum gloss',
-    price: 20,
-    freq: 'per wash',
-    features: [
-      'Everything in Premium',
-      'Ceramic seal',
-      'Undercarriage wash',
-      'Tire shine'
-    ],
-    cta: 'Go Ultimate'
-  }
-]
-
-// Keeping STEPS for potential future use
 const STEPS = [
-  {
-    title: 'Choose your wash',
-    desc: 'Pick at the kiosk or in the app—Rewards members save automatically.'
-  },
-  {
-    title: 'Roll through',
-    desc: 'Follow the guide rails and neutral—our team handles the rest.'
-  },
-  {
-    title: 'Shine & go',
-    desc: 'Spot-free dry, optional towel bays, and you’re on your way.'
-  }
+  { title: 'Choose your wash', desc: 'Pick at the kiosk or in the app — Rewards members save automatically.' },
+  { title: 'Roll through', desc: 'Follow the guide rails and shift to neutral — our equipment handles the rest.' },
+  { title: 'Shine & go', desc: 'Spot-free dry, optional towel bays, and you are on your way.' }
 ]
 
 const FAQS = [
-  {
-    q: 'Do you offer unlimited plans?',
-    a: 'Yes. Choose any package and switch to unlimited monthly billing anytime in the app. Cancel anytime.'
-  },
-  {
-    q: 'Is the wash safe for my vehicle?',
-    a: 'Our equipment and soaps are designed for modern clear coats, with soft-touch materials and filtered water.'
-  },
-  {
-    q: 'Where are wash locations?',
-    a: 'Use the Locations page or the app to find participating car wash sites near you.'
-  }
+  { q: 'Do you offer unlimited plans?', a: 'Yes. The Keep It Clean Club is unlimited monthly washing — sign up online and cancel anytime.' },
+  { q: 'Is the wash safe for my vehicle?', a: 'Our equipment and soaps are designed for modern clear coats, with soft-touch materials and filtered water.' },
+  { q: 'Where are wash locations?', a: 'Use the Locations page to find participating car wash sites near you.' }
 ]

--- a/ClarksPNS/src/pages/CarWash.tsx
+++ b/ClarksPNS/src/pages/CarWash.tsx
@@ -2,6 +2,7 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
 import { IconShine, IconFoam, IconFast, IconDrop } from '@/components/site/Icons'
+import Tilt from '@/components/site/Tilt'
 
 import img1 from '@/assets/images/carwashphotos/DJI_0019.jpg'
 import img2 from '@/assets/images/carwashphotos/DSC02583.jpg'
@@ -72,7 +73,7 @@ export default function CarWash () {
       <section
         id='club'
         aria-label='Keep It Clean Club'
-        className='py-12 md:py-20 bg-neutral-50 border-y border-black/10'
+        className='py-12 md:py-20 bg-surface-alt brand-stripes-light border-y border-black/10'
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='grid grid-cols-1 lg:grid-cols-2 items-center gap-10'>
@@ -161,9 +162,9 @@ export default function CarWash () {
 
           <div className='mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6'>
             {BENEFITS.map(b => (
+              <Tilt key={b.title}>
               <article
-                key={b.title}
-                className='rounded-2xl border border-black/10 p-6 hover:shadow-md transition-shadow bg-white'
+                className='rounded-2xl border border-black/10 brand-topline p-6 hover:shadow-md transition-shadow bg-white'
               >
                 <div className='mb-4'>
                   <span
@@ -176,6 +177,7 @@ export default function CarWash () {
                 <h3 className="font-['Oswald'] text-xl font-bold text-black">{b.title}</h3>
                 <p className='mt-2 text-black/70 text-sm leading-relaxed'>{b.desc}</p>
               </article>
+              </Tilt>
             ))}
           </div>
         </div>

--- a/ClarksPNS/src/pages/CarWash.tsx
+++ b/ClarksPNS/src/pages/CarWash.tsx
@@ -3,6 +3,7 @@
 import { Link } from 'react-router-dom'
 import { IconShine, IconFoam, IconFast, IconDrop } from '@/components/site/Icons'
 import Tilt from '@/components/site/Tilt'
+import WashTunnel from '@/components/site/WashTunnel'
 
 import img1 from '@/assets/images/carwashphotos/DJI_0019.jpg'
 import img2 from '@/assets/images/carwashphotos/DSC02583.jpg'
@@ -151,23 +152,8 @@ export default function CarWash () {
         </div>
       </section>
 
-      {/* === How it works — night mode === */}
-      <section aria-label='How it works' className='band-night brand-stripes py-14 text-white md:py-20'>
-        <div className='container mx-auto px-6 md:px-10'>
-          <h2 className='font-display text-4xl md:text-5xl'>Three steps to shine</h2>
-          <ol className='mt-10 grid grid-cols-1 gap-6 md:grid-cols-3'>
-            {STEPS.map((s, i) => (
-              <li key={s.title} className='relative rounded-2xl border border-white/15 bg-white/5 p-6'>
-                <span className='absolute -top-4 left-6 grid h-9 w-9 place-items-center rounded-xl bg-white font-display text-lg text-brand shadow-md'>
-                  {i + 1}
-                </span>
-                <h3 className='mt-2 font-display text-2xl'>{s.title}</h3>
-                <p className='mt-2 text-sm leading-relaxed text-white/75'>{s.desc}</p>
-              </li>
-            ))}
-          </ol>
-        </div>
-      </section>
+      {/* === Ride the tunnel — scroll scene === */}
+      <WashTunnel />
 
       {/* === Gift cards — 3D plastic === */}
       <section id='giftcards' aria-label='Car Wash Gift Cards' className='relative overflow-hidden bg-surface-alt brand-stripes-light py-14 md:py-20'>
@@ -252,11 +238,6 @@ const BENEFITS = [
   { icon: IconDrop, title: 'Spot-free dry', desc: 'Filtered water + high-velocity air for a streak-free result.' }
 ]
 
-const STEPS = [
-  { title: 'Choose your wash', desc: 'Pick at the kiosk or in the app — Rewards members save automatically.' },
-  { title: 'Roll through', desc: 'Follow the guide rails and shift to neutral — our equipment handles the rest.' },
-  { title: 'Shine & go', desc: 'Spot-free dry, optional towel bays, and you are on your way.' }
-]
 
 const FAQS = [
   { q: 'Do you offer unlimited plans?', a: 'Yes. The Keep It Clean Club is unlimited monthly washing — sign up online and cancel anytime.' },

--- a/ClarksPNS/src/pages/CarWash.tsx
+++ b/ClarksPNS/src/pages/CarWash.tsx
@@ -1,6 +1,7 @@
 // src/pages/CarWash.tsx
 import React from 'react'
 import { Link } from 'react-router-dom'
+import { IconShine, IconFoam, IconFast, IconDrop } from '@/components/site/Icons'
 
 import img1 from '@/assets/images/carwashphotos/DJI_0019.jpg'
 import img2 from '@/assets/images/carwashphotos/DSC02583.jpg'
@@ -168,7 +169,7 @@ export default function CarWash () {
                     aria-hidden
                     className='inline-flex h-12 w-12 items-center justify-center rounded-xl bg-brand/10'
                   >
-                    <b className='text-xl'>{b.icon}</b>
+                    <b.icon className='h-6 w-6 text-brand' />
                   </span>
                 </div>
                 <h3 className="font-['Oswald'] text-xl font-bold text-black">{b.title}</h3>
@@ -379,22 +380,22 @@ export default function CarWash () {
 
 const BENEFITS = [
   {
-    icon: '✨',
+    icon: IconShine,
     title: 'Showroom shine',
     desc: 'Poly sealant + spot-free rinse for a glossy, protected finish.'
   },
   {
-    icon: '🫧',
+    icon: IconFoam,
     title: 'Gentle clean',
     desc: 'Soft-touch materials and pH-balanced soaps safe for clear coat.'
   },
   {
-    icon: '⚡',
+    icon: IconFast,
     title: 'Fast lanes',
     desc: 'In-and-out convenience designed for busy mornings and quick stops.'
   },
   {
-    icon: '💧',
+    icon: IconDrop,
     title: 'Spot-free dry',
     desc: 'Filtered water + high-velocity air for a streak-free result.'
   }

--- a/ClarksPNS/src/pages/CarWash.tsx
+++ b/ClarksPNS/src/pages/CarWash.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { IconShine, IconFoam, IconFast, IconDrop } from '@/components/site/Icons'
 import Tilt from '@/components/site/Tilt'
 import WashTunnel from '@/components/site/WashTunnel'
+import WashWindow from '@/components/site/WashWindow'
 
 import img1 from '@/assets/images/carwashphotos/DJI_0019.jpg'
 import img2 from '@/assets/images/carwashphotos/DSC02583.jpg'
@@ -58,6 +59,8 @@ export default function CarWash () {
           </div>
         </div>
       </section>
+
+      <WashWindow />
 
       {/* === Keep It Clean Club — brand band === */}
       <section

--- a/ClarksPNS/src/pages/CarWash.tsx
+++ b/ClarksPNS/src/pages/CarWash.tsx
@@ -33,6 +33,7 @@ export default function CarWash () {
           aria-hidden
           className='pointer-events-none absolute -inset-40 rounded-[64px] blur-3xl bg-brand/10'
         />
+        <div aria-hidden className='water-sheen pointer-events-none absolute inset-0' />
 
         <div className='relative z-[1] pt-[16px] md:pt-[20px]'>
           <div className='container mx-auto px-6 md:px-10'>

--- a/ClarksPNS/src/pages/Careers.tsx
+++ b/ClarksPNS/src/pages/Careers.tsx
@@ -13,7 +13,7 @@ const PerkCard = ({
   children: React.ReactNode
 }) => (
   <article className='rounded-2xl border border-black/10 bg-white p-6 shadow-sm'>
-    <h3 className="font-['Oswald'] text-xl md:text-2xl font-bold text-black">
+    <h3 className="font-display text-xl md:text-2xl font-bold text-black">
       {title}
     </h3>
     <div className='prose prose-neutral mt-2 max-w-none text-black/80'>
@@ -54,10 +54,10 @@ export default function Careers () {
         />
         <div className='container mx-auto grid md:grid-cols-12 gap-8 px-6 md:px-10 py-14 md:py-16 items-center relative z-10'>
           <div className='md:col-span-8'>
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-white/80">
+            <p className="font-display tracking-wide text-xs uppercase text-white/80">
               Careers at Clark’s
             </p>
-            <h1 className="mt-2 font-['Oswald'] text-3xl md:text-5xl font-bold leading-tight">
+            <h1 className="mt-2 font-display text-3xl md:text-5xl font-bold leading-tight">
               Join the Clark’s family.
             </h1>
             <p className='mt-3 text-white/90 max-w-prose'>
@@ -103,10 +103,10 @@ export default function Careers () {
       <section id='why-clarks' className='py-12 md:py-16 bg-sky-50'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+            <p className="font-display tracking-wide text-xs uppercase text-brand">
               People First
             </p>
-            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">
               Build a career you’re proud of
             </h2>
             <p className='mt-3 text-black/70'>
@@ -144,10 +144,10 @@ export default function Careers () {
       <section className='py-12 md:py-16 bg-white border-y border-sky-100'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+            <p className="font-display tracking-wide text-xs uppercase text-brand">
               In Their Words
             </p>
-            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">
               What our team says
             </h2>
           </div>

--- a/ClarksPNS/src/pages/Charity.tsx
+++ b/ClarksPNS/src/pages/Charity.tsx
@@ -51,11 +51,11 @@ const Card = ({
 }) => (
   <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
     {eyebrow && (
-      <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+      <p className="font-display tracking-wide text-xs uppercase text-brand">
         {eyebrow}
       </p>
     )}
-    <h3 className="mt-1 font-['Oswald'] text-2xl md:text-3xl font-bold">
+    <h3 className="mt-1 font-display text-2xl md:text-3xl font-bold">
       {title}
     </h3>
     <div className="prose prose-neutral mt-3 max-w-none text-black/80">
@@ -189,10 +189,10 @@ export default function DonationsPage() {
       <section className="relative isolate bg-brand text-white">
         <div className="container mx-auto grid md:grid-cols-12 gap-8 px-6 md:px-10 py-14 md:py-16 items-center">
           <div className="md:col-span-7">
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-white/80">
+            <p className="font-display tracking-wide text-xs uppercase text-white/80">
               Clark Family Charity
             </p>
-            <h1 className="mt-2 font-['Oswald'] text-3xl md:text-5xl font-bold leading-tight">
+            <h1 className="mt-2 font-display text-3xl md:text-5xl font-bold leading-tight">
               Investing in the communities that invest in us
             </h1>
             <p className="mt-3 text-white/90 max-w-prose">
@@ -255,10 +255,10 @@ export default function DonationsPage() {
           <article className="rounded-2xl border border-black/10 bg-white shadow-sm overflow-hidden">
             <div className="grid lg:grid-cols-12 gap-0">
               <div className="lg:col-span-7 p-6 md:p-8">
-                <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+                <p className="font-display tracking-wide text-xs uppercase text-brand">
                   Our Why
                 </p>
-                <h3 className="mt-1 font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+                <h3 className="mt-1 font-display text-2xl md:text-3xl font-bold text-black">
                   Rodney Clark Memorial Scholarship
                 </h3>
                 <div className="prose prose-neutral mt-3 max-w-none text-black/80">
@@ -291,10 +291,10 @@ export default function DonationsPage() {
       <section id="golf" className="py-12 md:py-16 bg-white">
         <div className="container mx-auto px-6 md:px-10">
           <div className="max-w-3xl">
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+            <p className="font-display tracking-wide text-xs uppercase text-brand">
               Monday, May 11th, 2026
             </p>
-            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">
               Rodney Clark Memorial Golf Outing
             </h2>
             <div className="mt-3 text-black/70">
@@ -339,10 +339,10 @@ export default function DonationsPage() {
       <section id="scholarship" className="py-12 md:py-16 bg-white">
         <div className="container mx-auto px-6 md:px-10">
           <div className="max-w-3xl">
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+            <p className="font-display tracking-wide text-xs uppercase text-brand">
               $2,000 yearly · Renewable up to 8 semesters
             </p>
-            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">
               Clark Family Scholarship
             </h2>
             <div className="mt-3 text-black/70">
@@ -396,7 +396,7 @@ export default function DonationsPage() {
             {/* Left / Donate */}
             <div className="lg:w-1/2 lg:pr-10 py-8">
               <div className="h-full flex flex-col justify-center text-center lg:text-left">
-                <h2 className="font-['Oswald'] text-3xl font-bold text-black">
+                <h2 className="font-display text-3xl font-bold text-black">
                   Make a Donation
                 </h2>
                 <p className="mt-4 text-black/70">
@@ -423,7 +423,7 @@ export default function DonationsPage() {
             {/* Right / Questions */}
             <div className="lg:w-1/2 lg:pl-10 py-8">
               <div className="h-full flex flex-col justify-center text-center lg:text-left">
-                <h2 className="font-['Oswald'] text-3xl font-bold text-black">
+                <h2 className="font-display text-3xl font-bold text-black">
                   Have questions?
                 </h2>
                 <p className="mt-4 text-black/70">

--- a/ClarksPNS/src/pages/Community.tsx
+++ b/ClarksPNS/src/pages/Community.tsx
@@ -49,8 +49,9 @@ export default function Community() {
           </h1>
           <p className='mt-4 max-w-prose text-lg text-white/90 md:text-xl'>
             Every high school in Kentucky plays under the same banner we fill
-            up under. From the Sweet 16 hardwood to the state track meet,
-            Clark’s backs the kids and the communities that raised us.
+            up under — and from Ironton to Huntington, we back the hometown
+            teams of Ohio and West Virginia just as hard. If your kid plays,
+            we’re already in the stands.
           </p>
         </div>
         <div className='h-8 w-full bg-gradient-to-b from-transparent to-white md:h-12' />
@@ -80,8 +81,8 @@ export default function Community() {
         <p className='mt-6 max-w-prose text-black/70'>
           As the Official Fuel Sponsor of the Kentucky High School Athletic
           Association, Clark’s has a presence at every KHSAA state
-          championship event — and we like it that way. If your kid plays,
-          we’re already in the stands.
+          championship event — and across the river, the same goes for the
+          Ohio and West Virginia communities we call home.
         </p>
       </section>
 

--- a/ClarksPNS/src/pages/Community.tsx
+++ b/ClarksPNS/src/pages/Community.tsx
@@ -4,6 +4,7 @@
 import { Link } from 'react-router-dom'
 import { SEO } from '@/lib/seo'
 import { IconTrophy, IconPump, IconCap } from '@/components/site/Icons'
+import Tilt from '@/components/site/Tilt'
 
 import footballAd from "@/assets/images/Ashland FB - Clark's football AD (8.75 × 11.125 in) (1).png"
 import marshallAd from "@/assets/images/Clark's - Marshall Football Magazine (1) (1).png"
@@ -67,15 +68,14 @@ export default function Community() {
         </div>
         <div className='mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2'>
           {TITLES.map(t => (
-            <div
-              key={t.name}
-              className='rounded-2xl border border-black/10 bg-surface-alt p-6'
-            >
+            <Tilt key={t.name}>
+            <div className='rounded-2xl border border-black/10 brand-topline bg-surface-alt p-6'>
               <div className="font-['Oswald'] text-xl font-bold text-black">
                 {t.name}
               </div>
               <p className='mt-1 text-black/70'>{t.note}</p>
             </div>
+            </Tilt>
           ))}
         </div>
         <p className='mt-6 max-w-prose text-black/70'>

--- a/ClarksPNS/src/pages/Community.tsx
+++ b/ClarksPNS/src/pages/Community.tsx
@@ -41,11 +41,12 @@ export default function Community() {
               'repeating-linear-gradient(0deg, #fff 0 2px, transparent 2px 56px), repeating-linear-gradient(90deg, #fff 0 2px, transparent 2px 56px)'
           }}
         />
+        <div aria-hidden className='ghost-word ghost-word--light text-center'>GAME DAY</div>
         <div className='container relative z-[1] mx-auto px-6 py-16 text-white md:px-10 md:py-24'>
-          <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-white/70">
+          <div className="font-display text-xs uppercase tracking-[0.3em] text-white/70">
             Sports & Community
           </div>
-          <h1 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight md:text-6xl">
+          <h1 className="mt-2 font-display text-4xl font-bold leading-tight md:text-6xl">
             The Official Fuel of the KHSAA.
           </h1>
           <p className='mt-4 max-w-prose text-lg text-white/90 md:text-xl'>
@@ -62,7 +63,7 @@ export default function Community() {
       <section className='container mx-auto px-6 py-12 md:px-10'>
         <div className='flex items-center gap-3'>
           <IconTrophy className='h-8 w-8 text-brand' />
-          <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+          <h2 className="font-display text-3xl font-bold text-black md:text-4xl">
             Our name is on the trophy.
           </h2>
         </div>
@@ -70,7 +71,7 @@ export default function Community() {
           {TITLES.map(t => (
             <Tilt key={t.name}>
             <div className='rounded-2xl border border-black/10 brand-topline bg-surface-alt p-6'>
-              <div className="font-['Oswald'] text-xl font-bold text-black">
+              <div className="font-display text-xl font-bold text-black">
                 {t.name}
               </div>
               <p className='mt-1 text-black/70'>{t.note}</p>
@@ -91,7 +92,7 @@ export default function Community() {
         <div className='container mx-auto px-6 md:px-10'>
           <div className='flex items-center gap-3'>
             <IconCap className='h-8 w-8 text-brand' />
-            <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+            <h2 className="font-display text-3xl font-bold text-black md:text-4xl">
               Hometown colors
             </h2>
           </div>
@@ -126,13 +127,13 @@ export default function Community() {
       <section className='container mx-auto px-6 py-12 md:px-10'>
         <div className='flex items-center gap-3'>
           <IconPump className='h-8 w-8 text-brand' />
-          <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+          <h2 className="font-display text-3xl font-bold text-black md:text-4xl">
             Beyond the field
           </h2>
         </div>
         <div className='mt-6 grid grid-cols-1 gap-4 md:grid-cols-3'>
           <div className='rounded-2xl border border-black/10 p-6'>
-            <div className="font-['Oswald'] text-lg font-bold text-black">
+            <div className="font-display text-lg font-bold text-black">
               The arts
             </div>
             <p className='mt-1 text-sm text-black/70'>
@@ -141,7 +142,7 @@ export default function Community() {
             </p>
           </div>
           <div className='rounded-2xl border border-black/10 p-6'>
-            <div className="font-['Oswald'] text-lg font-bold text-black">
+            <div className="font-display text-lg font-bold text-black">
               Scholarships
             </div>
             <p className='mt-1 text-sm text-black/70'>
@@ -156,7 +157,7 @@ export default function Community() {
             </Link>
           </div>
           <div className='rounded-2xl border border-black/10 p-6'>
-            <div className="font-['Oswald'] text-lg font-bold text-black">
+            <div className="font-display text-lg font-bold text-black">
               Your cause
             </div>
             <p className='mt-1 text-sm text-black/70'>

--- a/ClarksPNS/src/pages/Community.tsx
+++ b/ClarksPNS/src/pages/Community.tsx
@@ -1,0 +1,175 @@
+// Sports & Community — the statewide sponsorships nobody could see on the
+// old site: Official Fuel of the KHSAA, title sponsor of the Girls' Sweet 16,
+// baseball, softball, and track & field, plus hometown support.
+import { Link } from 'react-router-dom'
+import { SEO } from '@/lib/seo'
+import { IconTrophy, IconPump, IconCap } from '@/components/site/Icons'
+
+import footballAd from "@/assets/images/Ashland FB - Clark's football AD (8.75 × 11.125 in) (1).png"
+import marshallAd from "@/assets/images/Clark's - Marshall Football Magazine (1) (1).png"
+
+const TITLES = [
+  {
+    name: 'Girls’ Basketball Sweet 16',
+    note: 'Title sponsor — it’s officially the Clark’s Pump-N-Shop Girls’ Sweet 16.'
+  },
+  { name: 'KHSAA Baseball', note: 'Title sponsor of the state championship.' },
+  { name: 'KHSAA Softball', note: 'Title sponsor of the state championship.' },
+  {
+    name: 'Track & Field',
+    note: 'Title sponsor of the state and region meets.'
+  }
+]
+
+export default function Community() {
+  return (
+    <main className='w-full overflow-x-clip bg-white'>
+      <SEO
+        title='Sports & Community — Clark’s Pump-N-Shop'
+        description='Official Fuel of the KHSAA. Title sponsor of the Girls’ Sweet 16, baseball, softball, and track & field. Backing hometown teams across the Tri-State.'
+        path='/community'
+      />
+
+      {/* Hero */}
+      <section className='relative isolate -mt-[16px] overflow-hidden bg-brand md:-mt-[20px]'>
+        <div
+          aria-hidden
+          className='pointer-events-none absolute inset-0 opacity-[0.1]'
+          style={{
+            background:
+              'repeating-linear-gradient(0deg, #fff 0 2px, transparent 2px 56px), repeating-linear-gradient(90deg, #fff 0 2px, transparent 2px 56px)'
+          }}
+        />
+        <div className='container relative z-[1] mx-auto px-6 py-16 text-white md:px-10 md:py-24'>
+          <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-white/70">
+            Sports & Community
+          </div>
+          <h1 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight md:text-6xl">
+            The Official Fuel of the KHSAA.
+          </h1>
+          <p className='mt-4 max-w-prose text-lg text-white/90 md:text-xl'>
+            Every high school in Kentucky plays under the same banner we fill
+            up under. From the Sweet 16 hardwood to the state track meet,
+            Clark’s backs the kids and the communities that raised us.
+          </p>
+        </div>
+        <div className='h-8 w-full bg-gradient-to-b from-transparent to-white md:h-12' />
+      </section>
+
+      {/* Title sponsorships */}
+      <section className='container mx-auto px-6 py-12 md:px-10'>
+        <div className='flex items-center gap-3'>
+          <IconTrophy className='h-8 w-8 text-brand' />
+          <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+            Our name is on the trophy.
+          </h2>
+        </div>
+        <div className='mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2'>
+          {TITLES.map(t => (
+            <div
+              key={t.name}
+              className='rounded-2xl border border-black/10 bg-surface-alt p-6'
+            >
+              <div className="font-['Oswald'] text-xl font-bold text-black">
+                {t.name}
+              </div>
+              <p className='mt-1 text-black/70'>{t.note}</p>
+            </div>
+          ))}
+        </div>
+        <p className='mt-6 max-w-prose text-black/70'>
+          As the Official Fuel Sponsor of the Kentucky High School Athletic
+          Association, Clark’s has a presence at every KHSAA state
+          championship event — and we like it that way. If your kid plays,
+          we’re already in the stands.
+        </p>
+      </section>
+
+      {/* Hometown creative */}
+      <section className='bg-surface-alt py-12'>
+        <div className='container mx-auto px-6 md:px-10'>
+          <div className='flex items-center gap-3'>
+            <IconCap className='h-8 w-8 text-brand' />
+            <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+              Hometown colors
+            </h2>
+          </div>
+          <p className='mt-2 max-w-prose text-black/70'>
+            Game programs, stadium boards, and matchday spreads — a sample of
+            how Clark’s shows up for the teams closest to home, from Ashland
+            football to Marshall gameday.
+          </p>
+          <div className='mt-6 grid grid-cols-1 gap-6 sm:grid-cols-2'>
+            {[footballAd, marshallAd].map((src, i) => (
+              <div
+                key={i}
+                className='overflow-hidden rounded-2xl border border-black/10 bg-white shadow-soft'
+              >
+                <img
+                  src={src}
+                  alt={
+                    i === 0
+                      ? 'Clark’s Pump-N-Shop Ashland football program ad'
+                      : 'Clark’s Pump-N-Shop Marshall football magazine ad'
+                  }
+                  loading='lazy'
+                  className='h-auto w-full object-contain'
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Beyond the field */}
+      <section className='container mx-auto px-6 py-12 md:px-10'>
+        <div className='flex items-center gap-3'>
+          <IconPump className='h-8 w-8 text-brand' />
+          <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+            Beyond the field
+          </h2>
+        </div>
+        <div className='mt-6 grid grid-cols-1 gap-4 md:grid-cols-3'>
+          <div className='rounded-2xl border border-black/10 p-6'>
+            <div className="font-['Oswald'] text-lg font-bold text-black">
+              The arts
+            </div>
+            <p className='mt-1 text-sm text-black/70'>
+              Proud supporter of the Paramount Arts Center and organizations
+              across the Ashland area.
+            </p>
+          </div>
+          <div className='rounded-2xl border border-black/10 p-6'>
+            <div className="font-['Oswald'] text-lg font-bold text-black">
+              Scholarships
+            </div>
+            <p className='mt-1 text-sm text-black/70'>
+              The Clark Family Scholarship and the Rodney Clark Memorial
+              Scholarship invest in students across the region.
+            </p>
+            <Link
+              to='/scholarship'
+              className='mt-3 inline-block text-sm font-medium text-brand'
+            >
+              About the scholarships →
+            </Link>
+          </div>
+          <div className='rounded-2xl border border-black/10 p-6'>
+            <div className="font-['Oswald'] text-lg font-bold text-black">
+              Your cause
+            </div>
+            <p className='mt-1 text-sm text-black/70'>
+              Local team, league, or event? Tell us how we can help.
+            </p>
+            <Link
+              to='/charity'
+              className='mt-3 inline-block text-sm font-medium text-brand'
+            >
+              Request a donation →
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/ClarksPNS/src/pages/Fleet.tsx
+++ b/ClarksPNS/src/pages/Fleet.tsx
@@ -1,0 +1,170 @@
+// Fleet & Diesel — the page for road crews, contractors, and anyone who
+// drives for a living. Real amenity counts from store data, the Marathon
+// fleet card, and a 3D-tilt fuel pump built in brand blue.
+import { useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { SEO } from '@/lib/seo'
+import { allStores } from '@/lib/stores'
+
+const DIESEL = allStores.filter(s => s.amenities?.diesel).length
+const KEROSENE = allStores.filter(s => s.amenities?.kerosene).length
+const ALWAYS_OPEN = allStores.filter(s => s.open24).length
+
+export default function Fleet() {
+  return (
+    <main className='w-full overflow-x-clip bg-white'>
+      <SEO
+        title='Fleet & Diesel — Clark’s Pump-N-Shop'
+        description={`Diesel at ${DIESEL} locations, kerosene at ${KEROSENE}, ${ALWAYS_OPEN} stores open 24 hours — plus the Clark's fleet card for your whole crew.`}
+        path='/fleet'
+      />
+
+      {/* Hero */}
+      <section className='relative isolate -mt-[16px] overflow-hidden bg-gradient-to-br from-[#101c4d] via-brand to-[#1b2f7d] md:-mt-[20px]'>
+        <div
+          aria-hidden
+          className='pointer-events-none absolute inset-0 opacity-[0.08]'
+          style={{
+            background:
+              'repeating-linear-gradient(135deg, #fff 0 2px, transparent 2px 30px)'
+          }}
+        />
+        <div className='container relative z-[1] mx-auto grid grid-cols-1 items-center gap-10 px-6 py-16 text-white md:px-10 md:py-24 lg:grid-cols-12'>
+          <div className='lg:col-span-7'>
+            <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-white/70">
+              Fleet & Diesel
+            </div>
+            <h1 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight md:text-6xl">
+              Built for the crews
+              <br />
+              that build the Tri-State.
+            </h1>
+            <p className='mt-4 max-w-prose text-lg text-white/90'>
+              Contractors, drivers, and working fleets run this region — and
+              Clark’s keeps them moving with diesel across three states, a
+              fleet card that works chain-wide, and stores that never close.
+            </p>
+            <div className='mt-8 flex flex-col gap-3 sm:flex-row'>
+              <a
+                href='https://www.marathonfleetcard.com/associations/?cc=M00528'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 font-semibold text-brand transition-transform hover:-translate-y-0.5'
+              >
+                Get the fleet card
+              </a>
+              <Link
+                to='/locations'
+                className='inline-flex items-center justify-center rounded-2xl border border-white/40 px-6 py-3 font-medium text-white transition-colors hover:bg-white/10'
+              >
+                Find diesel near you
+              </Link>
+            </div>
+          </div>
+          <div className='lg:col-span-5'>
+            <TiltPump />
+          </div>
+        </div>
+        <div className='h-8 w-full bg-gradient-to-b from-transparent to-white md:h-12' />
+      </section>
+
+      {/* Counts */}
+      <section className='container mx-auto px-6 py-12 md:px-10'>
+        <div className='grid grid-cols-1 gap-6 sm:grid-cols-3'>
+          <StatCard n={DIESEL} label='stores with diesel' />
+          <StatCard n={KEROSENE} label='stores with kerosene' />
+          <StatCard n={ALWAYS_OPEN} label='stores open 24 hours' />
+        </div>
+        <p className='mt-6 max-w-prose text-black/70'>
+          Every store page lists its fuel lineup, hours, and amenities — so
+          your drivers know before they roll in. Marathon and ARCO branded
+          fuel, chain-wide.
+        </p>
+        <Link
+          to='/locations'
+          className='mt-4 inline-flex items-center justify-center rounded-2xl bg-brand px-5 py-3 text-white transition-colors hover:bg-brand/90'
+        >
+          Browse all 63 stores
+        </Link>
+      </section>
+    </main>
+  )
+}
+
+function StatCard({ n, label }: { n: number; label: string }) {
+  return (
+    <div className='rounded-2xl border border-black/10 bg-surface-alt p-6'>
+      <div className="font-['Oswald'] text-5xl font-bold text-brand tabular-nums">
+        {n}
+      </div>
+      <div className='mt-1 font-medium text-black'>{label}</div>
+    </div>
+  )
+}
+
+/** Chunky brand fuel pump that tilts toward the cursor. */
+function TiltPump() {
+  const ref = useRef<HTMLDivElement | null>(null)
+
+  const onMove = (e: React.MouseEvent) => {
+    const el = ref.current
+    if (!el || matchMedia('(prefers-reduced-motion: reduce)').matches) return
+    const r = el.getBoundingClientRect()
+    const x = (e.clientX - r.left) / r.width - 0.5
+    const y = (e.clientY - r.top) / r.height - 0.5
+    el.style.transform = `rotateY(${x * 16}deg) rotateX(${-y * 10}deg)`
+  }
+
+  return (
+    <div className='[perspective:900px]'>
+      <div
+        ref={ref}
+        onMouseMove={onMove}
+        onMouseLeave={() => {
+          if (ref.current) ref.current.style.transform = ''
+        }}
+        className='mx-auto w-full max-w-[320px] transition-transform duration-200 [transform-style:preserve-3d]'
+      >
+        <svg viewBox='0 0 320 400' role='img' aria-label='Clark’s fuel pump'>
+          {/* base */}
+          <rect x='40' y='368' width='200' height='18' rx='6' fill='#0b153a' />
+          {/* body */}
+          <rect x='60' y='60' width='160' height='316' rx='18' fill='#1b2f7d' />
+          <rect x='60' y='60' width='160' height='316' rx='18' fill='url(#pumpshine)' />
+          {/* screen */}
+          <rect x='82' y='88' width='116' height='74' rx='10' fill='#0b153a' />
+          <text x='140' y='120' textAnchor='middle' fill='#0084FF' fontFamily='Oswald, sans-serif' fontSize='22' fontWeight='700'>CLARK’S</text>
+          <text x='140' y='146' textAnchor='middle' fill='#ffffff' fontFamily='Oswald, sans-serif' fontSize='13' letterSpacing='3'>FLEET READY</text>
+          {/* keypad */}
+          <g fill='#0084FF' opacity='0.85'>
+            <rect x='92' y='182' width='28' height='20' rx='4' />
+            <rect x='126' y='182' width='28' height='20' rx='4' />
+            <rect x='160' y='182' width='28' height='20' rx='4' />
+            <rect x='92' y='208' width='28' height='20' rx='4' />
+            <rect x='126' y='208' width='28' height='20' rx='4' />
+            <rect x='160' y='208' width='28' height='20' rx='4' />
+          </g>
+          {/* stripe */}
+          <rect x='60' y='250' width='160' height='14' fill='#0084FF' />
+          <rect x='60' y='264' width='160' height='6' fill='#e01f26' />
+          {/* nozzle + hose */}
+          <rect x='222' y='120' width='26' height='60' rx='8' fill='#0b153a' />
+          <path d='M235 180 C 258 260, 258 300, 226 352' stroke='#0b153a' strokeWidth='12' fill='none' strokeLinecap='round' />
+          <rect x='214' y='104' width='42' height='26' rx='8' fill='#0b153a' />
+          <rect x='248' y='108' width='22' height='12' rx='5' fill='#0b153a' />
+          {/* wordmark plate */}
+          <rect x='82' y='288' width='116' height='62' rx='10' fill='#ffffff' />
+          <text x='140' y='314' textAnchor='middle' fill='#263B95' fontFamily='Oswald, sans-serif' fontSize='17' fontWeight='700'>PUMP-N-SHOP</text>
+          <text x='140' y='334' textAnchor='middle' fill='#4B5563' fontFamily='Inter, sans-serif' fontSize='8.5' letterSpacing='0.5'>RETURN · REFRESH · REFUEL</text>
+          <defs>
+            <linearGradient id='pumpshine' x1='0' y1='0' x2='1' y2='0'>
+              <stop offset='0' stopColor='#ffffff' stopOpacity='0.14' />
+              <stop offset='0.45' stopColor='#ffffff' stopOpacity='0' />
+              <stop offset='1' stopColor='#000000' stopOpacity='0.18' />
+            </linearGradient>
+          </defs>
+        </svg>
+      </div>
+    </div>
+  )
+}

--- a/ClarksPNS/src/pages/Fleet.tsx
+++ b/ClarksPNS/src/pages/Fleet.tsx
@@ -1,7 +1,7 @@
 // Fleet & Diesel — the page for road crews, contractors, and anyone who
 // drives for a living. Real amenity counts from store data, the Marathon
 // fleet card, and a 3D-tilt fuel pump built in brand blue.
-import { useRef } from 'react'
+import { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { SEO } from '@/lib/seo'
 import { allStores } from '@/lib/stores'
@@ -88,8 +88,45 @@ export default function Fleet() {
         >
           Browse all 63 stores
         </Link>
+
+        <FleetCalc />
       </section>
     </main>
+  )
+}
+
+function FleetCalc() {
+  const [trucks, setTrucks] = useState(3)
+  const [gal, setGal] = useState(60)
+  const yearly = Math.round(trucks * gal * 20 * 52)
+  return (
+    <div className='mt-12 rounded-2xl border border-black/10 brand-topline bg-surface-alt p-6 md:p-8'>
+      <h2 className='font-display text-3xl text-black md:text-4xl'>What your crew earns</h2>
+      <p className='mt-1 max-w-prose text-sm text-black/60'>
+        Clark's Rewards pays 20 points per gallon. Fleet-card fuel discounts
+        are set by Marathon when you enroll.
+      </p>
+      <div className='mt-6 grid grid-cols-1 gap-8 md:grid-cols-3'>
+        <label className='block'>
+          <div className='flex items-baseline justify-between text-sm text-black/70'>
+            <span>Trucks</span>
+            <span className='font-display text-xl text-brand tabular-nums'>{trucks}</span>
+          </div>
+          <input type='range' min={1} max={25} value={trucks} onChange={e => setTrucks(+e.target.value)} className='mt-2 w-full accent-[#263B95]' />
+        </label>
+        <label className='block'>
+          <div className='flex items-baseline justify-between text-sm text-black/70'>
+            <span>Gallons per truck / week</span>
+            <span className='font-display text-xl text-brand tabular-nums'>{gal}</span>
+          </div>
+          <input type='range' min={10} max={200} step={5} value={gal} onChange={e => setGal(+e.target.value)} className='mt-2 w-full accent-[#263B95]' />
+        </label>
+        <div className='text-center md:text-right'>
+          <div className='font-display text-5xl leading-none text-brand tabular-nums'>{yearly.toLocaleString()}</div>
+          <div className='mt-1 text-sm text-black/60'>rewards points a year across the fleet</div>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/ClarksPNS/src/pages/Fleet.tsx
+++ b/ClarksPNS/src/pages/Fleet.tsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router-dom'
 import { SEO } from '@/lib/seo'
 import { allStores } from '@/lib/stores'
 import Tilt from '@/components/site/Tilt'
+import { track } from '@/lib/track'
 
 const DIESEL = allStores.filter(s => s.amenities?.diesel).length
 const KEROSENE = allStores.filter(s => s.amenities?.kerosene).length
@@ -51,6 +52,7 @@ export default function Fleet() {
                 href='https://www.marathonfleetcard.com/associations/?cc=M00528'
                 target='_blank'
                 rel='noopener noreferrer'
+                onClick={() => track('fleet_card_click', { placement: 'fleet_hero' })}
                 className='inline-flex items-center justify-center rounded-2xl bg-white px-6 py-3 font-semibold text-brand transition-transform hover:-translate-y-0.5'
               >
                 Get the fleet card

--- a/ClarksPNS/src/pages/Fleet.tsx
+++ b/ClarksPNS/src/pages/Fleet.tsx
@@ -5,6 +5,7 @@ import { useRef } from 'react'
 import { Link } from 'react-router-dom'
 import { SEO } from '@/lib/seo'
 import { allStores } from '@/lib/stores'
+import Tilt from '@/components/site/Tilt'
 
 const DIESEL = allStores.filter(s => s.amenities?.diesel).length
 const KEROSENE = allStores.filter(s => s.amenities?.kerosene).length
@@ -93,12 +94,14 @@ export default function Fleet() {
 
 function StatCard({ n, label }: { n: number; label: string }) {
   return (
-    <div className='rounded-2xl border border-black/10 bg-surface-alt p-6'>
+    <Tilt max={5}>
+    <div className='rounded-2xl border border-black/10 brand-topline bg-surface-alt p-6'>
       <div className="font-['Oswald'] text-5xl font-bold text-brand tabular-nums">
         {n}
       </div>
       <div className='mt-1 font-medium text-black'>{label}</div>
     </div>
+    </Tilt>
   )
 }
 

--- a/ClarksPNS/src/pages/Fleet.tsx
+++ b/ClarksPNS/src/pages/Fleet.tsx
@@ -30,12 +30,13 @@ export default function Fleet() {
               'repeating-linear-gradient(135deg, #fff 0 2px, transparent 2px 30px)'
           }}
         />
+        <div aria-hidden className='ghost-word ghost-word--light text-center'>DIESEL</div>
         <div className='container relative z-[1] mx-auto grid grid-cols-1 items-center gap-10 px-6 py-16 text-white md:px-10 md:py-24 lg:grid-cols-12'>
           <div className='lg:col-span-7'>
-            <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-white/70">
+            <div className="font-display text-xs uppercase tracking-[0.3em] text-white/70">
               Fleet & Diesel
             </div>
-            <h1 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight md:text-6xl">
+            <h1 className="mt-2 font-display text-4xl font-bold leading-tight md:text-6xl">
               Built for the crews
               <br />
               that build the Tri-State.
@@ -96,7 +97,7 @@ function StatCard({ n, label }: { n: number; label: string }) {
   return (
     <Tilt max={5}>
     <div className='rounded-2xl border border-black/10 brand-topline bg-surface-alt p-6'>
-      <div className="font-['Oswald'] text-5xl font-bold text-brand tabular-nums">
+      <div className="font-display text-5xl font-bold text-brand tabular-nums">
         {n}
       </div>
       <div className='mt-1 font-medium text-black'>{label}</div>
@@ -136,8 +137,8 @@ function TiltPump() {
           <rect x='60' y='60' width='160' height='316' rx='18' fill='url(#pumpshine)' />
           {/* screen */}
           <rect x='82' y='88' width='116' height='74' rx='10' fill='#0b153a' />
-          <text x='140' y='120' textAnchor='middle' fill='#0084FF' fontFamily='Oswald, sans-serif' fontSize='22' fontWeight='700'>CLARK’S</text>
-          <text x='140' y='146' textAnchor='middle' fill='#ffffff' fontFamily='Oswald, sans-serif' fontSize='13' letterSpacing='3'>FLEET READY</text>
+          <text x='140' y='120' textAnchor='middle' fill='#0084FF' fontFamily='"Bebas Neue", Oswald, sans-serif' fontSize='22' fontWeight='700'>CLARK’S</text>
+          <text x='140' y='146' textAnchor='middle' fill='#ffffff' fontFamily='"Bebas Neue", Oswald, sans-serif' fontSize='13' letterSpacing='3'>FLEET READY</text>
           {/* keypad */}
           <g fill='#0084FF' opacity='0.85'>
             <rect x='92' y='182' width='28' height='20' rx='4' />
@@ -157,7 +158,7 @@ function TiltPump() {
           <rect x='248' y='108' width='22' height='12' rx='5' fill='#0b153a' />
           {/* wordmark plate */}
           <rect x='82' y='288' width='116' height='62' rx='10' fill='#ffffff' />
-          <text x='140' y='314' textAnchor='middle' fill='#263B95' fontFamily='Oswald, sans-serif' fontSize='17' fontWeight='700'>PUMP-N-SHOP</text>
+          <text x='140' y='314' textAnchor='middle' fill='#263B95' fontFamily='"Bebas Neue", Oswald, sans-serif' fontSize='17' fontWeight='700'>PUMP-N-SHOP</text>
           <text x='140' y='334' textAnchor='middle' fill='#4B5563' fontFamily='Inter, sans-serif' fontSize='8.5' letterSpacing='0.5'>RETURN · REFRESH · REFUEL</text>
           <defs>
             <linearGradient id='pumpshine' x1='0' y1='0' x2='1' y2='0'>

--- a/ClarksPNS/src/pages/Food.tsx
+++ b/ClarksPNS/src/pages/Food.tsx
@@ -112,7 +112,7 @@ export default function Food () {
             {/* Text (left) */}
             <div className='w-full lg:flex-1'>
               <div className='max-w-[900px]'>
-                <h1 className="font-['Oswald'] font-bold text-black text-4xl md:text-6xl leading-tight">
+                <h1 className="font-display font-bold text-black text-4xl md:text-6xl leading-tight">
                   Hot, fresh, and fast.
                   <br />
                   right inside select locations
@@ -156,12 +156,12 @@ export default function Food () {
       {/* Gallery */}
       <section
         aria-label='Food Gallery'
-        className='py-12 md:py-20 bg-neutral-50 border-y border-black/10'
+        className='band-night brand-stripes relative py-12 md:py-20 text-white'
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
-              Food Gallery
+            <h2 className="font-display text-3xl md:text-4xl font-bold">
+              Hot out of our kitchens
             </h2>
           </div>
           <div
@@ -192,7 +192,7 @@ function BrandMenus () {
     <section aria-label='Restaurant Menus' className='py-12 md:py-20 bg-surface-alt brand-stripes-light'>
       <div className='container mx-auto px-6 md:px-10'>
         <div className='max-w-3xl'>
-          {/* <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">Our In-Store Kitchens</h2> */}
+          {/* <h2 className="font-display text-3xl md:text-4xl font-bold text-black">Our In-Store Kitchens</h2> */}
         </div>
         <div className='mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6'>
           <MenuBlock
@@ -343,7 +343,7 @@ function MenuBlock ({
           />
         </div>
         <div className='min-w-0 grow'>
-          <h3 className="font-['Oswald'] text-xl md:text-2xl font-bold text-black">
+          <h3 className="font-display text-xl md:text-2xl font-bold text-black">
             {name}
           </h3>
           <p className='mt-1 text-black/70 text-sm md:text-base line-clamp-2'>

--- a/ClarksPNS/src/pages/Food.tsx
+++ b/ClarksPNS/src/pages/Food.tsx
@@ -41,6 +41,11 @@ for (const st of allStores) {
   }
 }
 
+const IS_BREAKFAST = new Date().getHours() + new Date().getMinutes() / 60 < 10.5
+const BRANDS_ORDERED = IS_BREAKFAST
+  ? [...FOOD_BRANDS].sort((a, b) => (a.slug === 'clarks-cafe' ? -1 : b.slug === 'clarks-cafe' ? 1 : 0))
+  : FOOD_BRANDS
+
 export default function Food () {
   const [idx, setIdx] = React.useState(0)
   const [fading, setFading] = React.useState(false)
@@ -106,7 +111,7 @@ export default function Food () {
           </p>
 
           <div className='mt-10 grid grid-cols-1 gap-8 lg:grid-cols-2 [perspective:1600px]'>
-            {FOOD_BRANDS.map(brand => {
+            {BRANDS_ORDERED.map(brand => {
               const stores = STORES_BY_KITCHEN[brand.kitchenName] || []
               const highlights = brand.sections[0]?.items.slice(0, 3) || []
               return (
@@ -119,7 +124,9 @@ export default function Food () {
                         className='h-12 w-auto object-contain'
                       />
                       <span className='shrink-0 rounded-full bg-brand/10 px-3 py-1 font-display text-sm tracking-[0.08em] text-brand'>
-                        {stores.length} STORES
+                        {IS_BREAKFAST && brand.slug === 'clarks-cafe'
+                          ? 'BREAKFAST IS ON'
+                          : `${stores.length} STORES`}
                       </span>
                     </div>
                     <h3 className='mt-4 font-display text-3xl text-black'>{brand.name}</h3>

--- a/ClarksPNS/src/pages/Food.tsx
+++ b/ClarksPNS/src/pages/Food.tsx
@@ -189,7 +189,7 @@ export default function Food () {
 
 function BrandMenus () {
   return (
-    <section aria-label='Restaurant Menus' className='py-12 md:py-20 bg-white'>
+    <section aria-label='Restaurant Menus' className='py-12 md:py-20 bg-surface-alt brand-stripes-light'>
       <div className='container mx-auto px-6 md:px-10'>
         <div className='max-w-3xl'>
           {/* <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">Our In-Store Kitchens</h2> */}
@@ -325,7 +325,7 @@ function MenuBlock ({
   return (
     <article
       id={id}
-      className='rounded-2xl border border-black/10 bg-neutral-50'
+      className='rounded-2xl border border-black/10 brand-topline bg-white shadow-soft'
     >
       {/* Toggle header */}
       <button

--- a/ClarksPNS/src/pages/Food.tsx
+++ b/ClarksPNS/src/pages/Food.tsx
@@ -1,17 +1,31 @@
-// src/pages/Food.tsx
+// Food at Clark's — fully dynamic. No accordions, no hidden menus:
+// every kitchen shows its menu highlights, its store count, and the
+// actual stores that carry it, always visible, in 3D-tilt cards.
 import React from 'react'
 import { Link } from 'react-router-dom'
+import Tilt from '@/components/site/Tilt'
+import { IconClose } from '@/components/site/Icons'
+import { FOOD_BRANDS } from '@/content/menus'
+import { allStores, namedKitchens, type Store } from '@/lib/stores'
+
 import champsLogo from '@/assets/images/champschickenlogo.png'
 import hangarLogo from '@/assets/images/Hangar54Logo_02-1.png'
-import jacksLogo from '@/assets/images/jacksdelilogo.webp'
 import cafeLogo from '@/assets/images/clarkscafelogo.webp'
 import kkcLogo from '@/assets/images/krispykrunchychickenlogo.webp'
 import coopersLogo from '@/assets/images/CoopersExpressLogo.png'
-
+import jacksLogo from '@/assets/images/jacksdelilogo.webp'
 
 import foodHeroVideo from '@/assets/videos/30sFoodVideo_1080.mp4'
 
-/** === Auto-import: sitewide food gallery === */
+const LOGO: Record<string, string> = {
+  'krispy-krunchy': kkcLogo,
+  'hangar-54': hangarLogo,
+  'clarks-cafe': cafeLogo,
+  champs: champsLogo,
+  coopers: coopersLogo
+}
+
+/** Sitewide food gallery (unchanged asset source) */
 const ALL_GALLERY = Object.values(
   import.meta.glob('@/assets/food-gallery/**/*.{jpg,jpeg,png,webp,avif}', {
     eager: true,
@@ -19,65 +33,18 @@ const ALL_GALLERY = Object.values(
   })
 ) as string[]
 
-
-/** === Auto-import: menus (PDFs + images) — merged sources === */
-
-/** === Auto-import: menus (PDFs + images) — search ANY menus/ under /src/** === */
-
-// 1) Alias-prefixed (covers @/)
-const _MENU_PDFS_A = import.meta.glob('@/**/menus/**/*.{pdf}', {
-  eager: true,
-  as: 'url'
-}) as Record<string, string>
-const _MENU_IMAGES_A = import.meta.glob('@/**/menus/**/*.{jpg,jpeg,png,webp,avif}', {
-  eager: true,
-  as: 'url'
-}) as Record<string, string>
-
-// 2) Absolute from project root (covers /src/**)
-const _MENU_PDFS_B = import.meta.glob('/src/**/menus/**/*.{pdf}', {
-  eager: true,
-  as: 'url'
-}) as Record<string, string>
-const _MENU_IMAGES_B = import.meta.glob('/src/**/menus/**/*.{jpg,jpeg,png,webp,avif}', {
-  eager: true,
-  as: 'url'
-}) as Record<string, string>
-
-// 3) Merge both
-const MENU_PDFS: Record<string, string> = { ..._MENU_PDFS_A, ..._MENU_PDFS_B }
-const MENU_IMAGES: Record<string, string> = { ..._MENU_IMAGES_A, ..._MENU_IMAGES_B }
-
-// --- helpers (place right under MENU_IMAGES) ---
-function brandFromPath (p: string) {
-  // Normalize slashes for Windows/posix and lowercase
-  const norm = p.replace(/\\/g, '/').toLowerCase()
-  const marker = '/menus/'
-  const at = norm.indexOf(marker)
-  if (at === -1) return ''
-  const after = norm.slice(at + marker.length)
-  const brand = after.split('/')[0] || ''
-  return brand
-}
-
-function pickByBrand<T extends Record<string, string>> (files: T, key: string) {
-  const target = key.toLowerCase()
-  return Object.entries(files)
-    .filter(([path]) => brandFromPath(path) === target)
-    .map(([, url]) => url)
-}
-
-// --- collectMenus (replace your existing one) ---
-function collectMenus (brandKey: string) {
-  const pdfs = pickByBrand(MENU_PDFS, brandKey)
-  const images = pickByBrand(MENU_IMAGES, brandKey)
-  return { pdfs, images }
+/** Stores carrying each kitchen, precomputed once. */
+const STORES_BY_KITCHEN: Record<string, Store[]> = {}
+for (const st of allStores) {
+  for (const k of namedKitchens(st)) {
+    ;(STORES_BY_KITCHEN[k] ||= []).push(st)
+  }
 }
 
 export default function Food () {
   const [idx, setIdx] = React.useState(0)
   const [fading, setFading] = React.useState(false)
-  const gallery = ALL_GALLERY.length ? ALL_GALLERY : []
+  const gallery = ALL_GALLERY
 
   React.useEffect(() => {
     if (!gallery.length) return
@@ -91,54 +58,35 @@ export default function Food () {
     return () => clearInterval(timer)
   }, [gallery.length])
 
-  const triplet = (start: number) =>
-    [0, 1, 2]
-      .map(k => gallery[(start + k) % Math.max(gallery.length, 1)])
-      .filter(Boolean)
-
-  const visible = triplet(idx)
+  const visible = [0, 1, 2]
+    .map(k => gallery[(idx + k) % Math.max(gallery.length, 1)])
+    .filter(Boolean)
 
   return (
     <main className='relative -mt-6 w-full overflow-x-clip bg-white'>
-      {/* Hero */}
-      {/* === Video Hero (no tint) – mobile & desktop === */}
-      {/* === Video Hero (bottom-left content, tinted) === */}
+      {/* === Hero === */}
       <section
         aria-label='Food at Clarks'
-        className='relative isolate z-0 w-full -mt-[16px] md:-mt-[20px] bg-gradient-to-br from-white via-white to-neutral-50'
+        className='relative isolate z-0 w-full -mt-[16px] md:-mt-[20px] bg-surface-alt brand-stripes-light'
       >
         <div className='container mx-auto px-6 md:px-10 py-10 md:py-14'>
           <div className='flex flex-col lg:flex-row items-center lg:items-start gap-6 lg:gap-10'>
-            {/* Text (left) */}
             <div className='w-full lg:flex-1'>
               <div className='max-w-[900px]'>
-                <h1 className="font-display font-bold text-black text-4xl md:text-6xl leading-tight">
+                <h1 className='font-display text-black text-5xl md:text-7xl leading-none'>
                   Hot, fresh, and fast.
-                  <br />
-                  right inside select locations
                 </h1>
-
-                {/* Longer accent rule */}
                 <div className='mt-4 h-1 w-56 rounded bg-brand' />
-
                 <p className='mt-5 text-black/70 text-lg md:text-2xl max-w-prose'>
-                  From crispy tenders and deli stacks to melty pizza and
-                  breakfast favorites, our in-store kitchens serve up
-                  crowd-pleasers every day.
+                  Five real kitchens inside our stores — crispy tenders, deli
+                  stacks, melty pizza, and scratch breakfast. Every menu below,
+                  every store that serves it.
                 </p>
               </div>
             </div>
-
-            {/* Video (right) — slightly larger box */}
             <div className='w-full lg:w-auto'>
               <div className='rounded-2xl overflow-hidden border border-black/10 shadow-lg max-w-[640px] mx-auto'>
-                <video
-                  className='block w-full h-auto' /* scales naturally */
-                  autoPlay
-                  playsInline
-                  muted
-                  loop
-                >
+                <video className='block w-full h-auto' autoPlay playsInline muted loop>
                   <source src={foodHeroVideo} type='video/mp4' />
                 </video>
               </div>
@@ -147,321 +95,125 @@ export default function Food () {
         </div>
       </section>
 
-      {/* Menus */}
-      <BrandMenus />
+      {/* === Kitchens — always open, always dynamic === */}
+      <section aria-label='Our kitchens' className='band-night brand-stripes relative py-14 text-white md:py-20'>
+        <div aria-hidden className='ghost-word ghost-word--light text-center'>KITCHENS</div>
+        <div className='container relative mx-auto px-6 md:px-10'>
+          <h2 className='font-display text-4xl md:text-6xl'>Pick your kitchen.</h2>
+          <p className='mt-2 max-w-prose text-white/80'>
+            Menus straight from the boards in store — prices and availability
+            may vary by location.
+          </p>
 
-      {/* DEV: show glob keys with ?debug=menus */}
-<MenusDiagnostics />
+          <div className='mt-10 grid grid-cols-1 gap-8 lg:grid-cols-2 [perspective:1600px]'>
+            {FOOD_BRANDS.map(brand => {
+              const stores = STORES_BY_KITCHEN[brand.kitchenName] || []
+              const highlights = brand.sections[0]?.items.slice(0, 3) || []
+              return (
+                <Tilt key={brand.slug} max={4}>
+                  <article className='h-full rounded-2xl border border-white/15 bg-white p-7 text-black shadow-xl'>
+                    <div className='flex items-center justify-between gap-4'>
+                      <img
+                        src={LOGO[brand.slug]}
+                        alt={`${brand.name} logo`}
+                        className='h-12 w-auto object-contain'
+                      />
+                      <span className='shrink-0 rounded-full bg-brand/10 px-3 py-1 font-display text-sm tracking-[0.08em] text-brand'>
+                        {stores.length} STORES
+                      </span>
+                    </div>
+                    <h3 className='mt-4 font-display text-3xl text-black'>{brand.name}</h3>
+                    <p className='mt-1 text-sm text-black/60'>{brand.tagline}</p>
 
-      {/* Gallery */}
-      <section
-        aria-label='Food Gallery'
-        className='band-night brand-stripes relative py-12 md:py-20 text-white'
-      >
-        <div className='container mx-auto px-6 md:px-10'>
-          <div className='max-w-3xl'>
-            <h2 className="font-display text-3xl md:text-4xl font-bold">
-              Hot out of our kitchens
-            </h2>
+                    {/* Menu highlights */}
+                    <ul className='mt-4 divide-y divide-black/5 border-y border-black/5'>
+                      {highlights.map(item => (
+                        <li key={item.name} className='flex items-baseline justify-between gap-3 py-2 text-sm'>
+                          <span className='font-medium'>{item.name}</span>
+                          {item.price && (
+                            <span className='shrink-0 font-semibold tabular-nums'>{item.price}</span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+
+                    {/* Stores carrying it */}
+                    <div className='mt-4 flex flex-wrap gap-1.5'>
+                      {stores.slice(0, 4).map(s => (
+                        <Link
+                          key={s.slug}
+                          to={`/locations/${s.slug}`}
+                          className='rounded-full border border-black/10 bg-surface-alt px-3 py-1 text-xs text-black/70 transition-colors hover:border-brand hover:text-brand'
+                        >
+                          {s.name} · {(s.state || '').toUpperCase()}
+                        </Link>
+                      ))}
+                      {stores.length > 4 && (
+                        <Link
+                          to={`/food/${brand.slug}#find`}
+                          className='rounded-full bg-brand/10 px-3 py-1 text-xs font-medium text-brand'
+                        >
+                          +{stores.length - 4} more stores
+                        </Link>
+                      )}
+                    </div>
+
+                    <div className='mt-5 flex flex-wrap gap-2'>
+                      <Link
+                        to={`/food/${brand.slug}`}
+                        className='inline-flex items-center justify-center rounded-xl bg-brand px-5 py-2.5 text-white transition-colors hover:bg-brand/90'
+                      >
+                        Full menu
+                      </Link>
+                      <Link
+                        to={`/food/${brand.slug}#find`}
+                        className='inline-flex items-center justify-center rounded-xl border border-brand/40 px-5 py-2.5 text-brand transition-colors hover:bg-brand/5'
+                      >
+                        All {stores.length} stores
+                      </Link>
+                    </div>
+                  </article>
+                </Tilt>
+              )
+            })}
+
+            {/* Jack's Deli — no published menu yet */}
+            <Tilt max={4}>
+              <article className='h-full rounded-2xl border border-white/15 bg-white/10 p-7 text-white'>
+                <img src={jacksLogo} alt="Jack's Deli logo" className='h-12 w-auto object-contain' />
+                <h3 className='mt-4 font-display text-3xl'>Jack’s Deli</h3>
+                <p className='mt-1 text-sm text-white/70'>
+                  Stacked sandwiches, salads, and deli classics — menu board
+                  coming to the site soon.
+                </p>
+                <Link
+                  to='/locations'
+                  className='mt-5 inline-flex items-center justify-center rounded-xl bg-white px-5 py-2.5 font-semibold text-brand transition-transform hover:-translate-y-0.5'
+                >
+                  Find a location
+                </Link>
+              </article>
+            </Tilt>
           </div>
+        </div>
+      </section>
+
+      {/* === Gallery === */}
+      <section aria-label='Food Gallery' className='band-night brand-stripes relative border-t border-white/10 py-12 text-white md:py-20'>
+        <div className='container mx-auto px-6 md:px-10'>
+          <h2 className='font-display text-3xl md:text-4xl'>Hot out of our kitchens</h2>
           <div
             className={`mt-8 grid grid-cols-1 sm:grid-cols-3 gap-4 transition-opacity duration-300 ${
               fading ? 'opacity-0' : 'opacity-100'
             }`}
           >
-            {visible.length ? (
-              visible.map(src => <GalleryImage key={src} src={src} />)
-            ) : (
-              <div className='sm:col-span-3'>
-                <PlaceholderEmpty msg='Add images under src/assets/food-gallery to populate this gallery.' />
-              </div>
-            )}
+            {visible.map(src => (
+              <GalleryImage key={src} src={src} />
+            ))}
           </div>
         </div>
       </section>
     </main>
-  )
-}
-
-/* ========================
-   Brand Menus Section
-   ======================== */
-
-function BrandMenus () {
-  return (
-    <section aria-label='Restaurant Menus' className='py-12 md:py-20 bg-surface-alt brand-stripes-light'>
-      <div className='container mx-auto px-6 md:px-10'>
-        <div className='max-w-3xl'>
-          {/* <h2 className="font-display text-3xl md:text-4xl font-bold text-black">Our In-Store Kitchens</h2> */}
-        </div>
-        <div className='mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6'>
-          <MenuBlock
-            id='champs-chicken'
-            brandKey='champs'
-            logo={champsLogo}
-            name='Champs Chicken'
-            desc='Crispy tenders, signature sides, and sauces.'
-          />
-          <MenuBlock
-            id='hangar-54-pizza'
-            brandKey='hangar54'
-            logo={hangarLogo}
-            name='Hangar 54 Pizza'
-            desc='Slices and whole pies—hot from the oven.'
-          />
-          <MenuBlock
-            id='jacks-deli'
-            brandKey='jacks-deli'
-            logo={jacksLogo}
-            name="Jack's Deli"
-            desc='Stacked sandwiches, salads, and deli classics.'
-          />
-          <MenuBlock
-            id='clarks-cafe'
-            brandKey='clarks-cafe'
-            logo={cafeLogo}
-            name='Clarks Cafe'
-            desc='Breakfast sandwiches, pastries, and coffee.'
-          />
-          <MenuBlock
-            id='krispy-krunchy-chicken'
-            brandKey='krispy-krunchy'
-            logo={kkcLogo}
-            name='Krispy Krunchy Chicken'
-            desc='Louisiana-style chicken, biscuits, and sides.'
-          />
-          <MenuBlock
-            id='coopers-chicken'
-            brandKey='coopers'
-            logo={coopersLogo} // or replace with a Coopers logo if you have one
-            name="Cooper's Chicken"
-            desc='Famous fried chicken and homestyle sides.'
-          />
-        </div>
-      </div>
-    </section>
-  )
-}
-
-function MenusDiagnostics() {
-  const [show, setShow] = React.useState(
-    typeof window !== 'undefined' &&
-    new URLSearchParams(window.location.search).get('debug') === 'menus'
-  )
-
-  if (!show) return null
-  return (
-    <section className="fixed bottom-3 right-3 z-[9999] max-w-[90vw] rounded-xl border border-black/20 bg-white/95 p-4 shadow-lg text-xs text-black">
-      <div className="flex items-center justify-between gap-3">
-        <strong>Menus Diagnostics</strong>
-        <button
-          onClick={() => setShow(false)}
-          className="rounded-md px-2 py-1 bg-black text-white"
-        >
-          Close
-        </button>
-      </div>
-      <div className="mt-2 grid gap-2">
-        <div><b>MENU_IMAGES keys:</b> {Object.keys(MENU_IMAGES).length}</div>
-        <div className="max-h-40 overflow-auto">
-          <pre className="whitespace-pre-wrap break-all">
-{JSON.stringify(Object.keys(MENU_IMAGES).slice(0, 30), null, 2)}
-          </pre>
-        </div>
-        <div><b>MENU_PDFS keys:</b> {Object.keys(MENU_PDFS).length}</div>
-        <div className="max-h-40 overflow-auto">
-          <pre className="whitespace-pre-wrap break-all">
-{JSON.stringify(Object.keys(MENU_PDFS).slice(0, 30), null, 2)}
-          </pre>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-
-/** Brands with a dedicated menu page at /food/<slug> */
-const MENU_PAGE_SLUG: Record<string, string> = {
-  champs: 'champs',
-  hangar54: 'hangar-54',
-  'clarks-cafe': 'clarks-cafe',
-  'krispy-krunchy': 'krispy-krunchy',
-  coopers: 'coopers'
-}
-
-function MenuBlock ({
-  id,
-  brandKey,
-  logo,
-  name,
-  desc
-}: {
-  id: string
-  brandKey: string
-  logo: string
-  name: string
-  desc: string
-}) {
-  const { pdfs, images } = collectMenus(brandKey)
-  const menuPage = MENU_PAGE_SLUG[brandKey]
-  const [lightbox, setLightbox] = React.useState<string | null>(null)
-
-  // Accordion state (collapsed by default). Auto-open if URL hash matches this block's id.
-  const [open, setOpen] = React.useState(false)
-  React.useEffect(() => {
-    if (typeof window !== 'undefined' && window.location.hash === `#${id}`) {
-      setOpen(true)
-      // small scroll nudge so the opened content is visible under sticky headers, if any
-      setTimeout(
-        () =>
-          document
-            .getElementById(id)
-            ?.scrollIntoView({ behavior: 'smooth', block: 'start' }),
-        0
-      )
-    }
-  }, [id])
-
-  return (
-    <article
-      id={id}
-      className='rounded-2xl border border-black/10 brand-topline bg-white shadow-soft'
-    >
-      {/* Toggle header */}
-      <button
-        type='button'
-        onClick={() => setOpen(v => !v)}
-        className='flex w-full items-center gap-4 p-6 text-left'
-        aria-expanded={open}
-        aria-controls={`${id}-panel`}
-      >
-        <div className='h-12 shrink-0 flex items-center'>
-          <img
-            src={logo}
-            alt={`${name} logo`}
-            className='h-12 w-auto object-contain'
-          />
-        </div>
-        <div className='min-w-0 grow'>
-          <h3 className="font-display text-xl md:text-2xl font-bold text-black">
-            {name}
-          </h3>
-          <p className='mt-1 text-black/70 text-sm md:text-base line-clamp-2'>
-            {desc}
-          </p>
-        </div>
-        <Chevron open={open} className='text-brand' />
-      </button>
-
-      {/* Animated panel */}
-      <div
-        id={`${id}-panel`}
-        className={`
-          grid transition-[grid-template-rows] duration-300 ease-out
-          ${open ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'}
-        `}
-      >
-        <div className='overflow-hidden'>
-          <div className='px-6 pb-6 space-y-4'>
-            {/* Full menu page */}
-            {menuPage && (
-              <Link
-                to={`/food/${menuPage}`}
-                className='inline-flex items-center justify-center rounded-xl px-4 py-2 bg-brand text-white hover:bg-brand/90 transition-colors'
-              >
-                View full menu →
-              </Link>
-            )}
-
-            {/* PDFs */}
-            {pdfs.length ? (
-              <div className='flex flex-wrap gap-2'>
-                {pdfs.map((url, i) => (
-                  <a
-                    key={url}
-                    href={url}
-                    target='_blank'
-                    rel='noreferrer'
-                    className='inline-flex items-center justify-center rounded-xl px-4 py-2 bg-brand text-white hover:bg-brand/90 transition-colors'
-                  >
-                    Open Menu PDF{i > 0 ? ` ${i + 1}` : ''}
-                  </a>
-                ))}
-              </div>
-            ) : !menuPage ? (
-              <p className='text-black/60 text-sm'>Menu PDF coming soon.</p>
-            ) : null}
-
-            {/* Images */}
-            {images.length ? (
-              <div className='grid grid-cols-1 gap-3'>
-                {images.map(src => (
-                  <button
-                    key={src}
-                    onClick={() => setLightbox(src)}
-                    className='group block w-full'
-                    title={`${name} menu image`}
-                  >
-                    <div className='relative overflow-hidden rounded-xl border border-black/10 bg-white'>
-                      <img
-                        src={src}
-                        alt={`${name} menu`}
-                        loading='lazy'
-                        className='w-full h-auto object-contain'
-                      />
-                    </div>
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <p className='text-black/60 text-sm'>Menu images coming soon.</p>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Lightbox (unchanged) */}
-      {lightbox && (
-        <div className='fixed inset-0 bg-black/70 z-50 flex items-center justify-center'>
-          <div className='relative w-[90%] max-h-[90%]'>
-            <button
-              onClick={() => setLightbox(null)}
-              className='absolute top-2 right-2 bg-brand text-white rounded-full px-3 py-1 shadow-lg'
-              aria-label='Close image'
-            >
-              ✕
-            </button>
-            <img
-              src={lightbox}
-              alt='Menu full view'
-              className='w-full h-auto max-h-[90vh] object-contain rounded-xl'
-            />
-          </div>
-        </div>
-      )}
-    </article>
-  )
-}
-
-/* Simple chevron icon that rotates when open */
-function Chevron ({
-  open,
-  className = ''
-}: {
-  open: boolean
-  className?: string
-}) {
-  return (
-    <svg
-      className={`h-6 w-6 shrink-0 transition-transform duration-300 ${
-        open ? 'rotate-180' : 'rotate-0'
-      } ${className}`}
-      viewBox='0 0 20 20'
-      fill='currentColor'
-      aria-hidden='true'
-    >
-      <path d='M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.06l3.71-3.83a.75.75 0 1 1 1.08 1.04l-4.24 4.38a.75.75 0 0 1-1.08 0L5.21 8.27a.75.75 0 0 1 .02-1.06z' />
-    </svg>
   )
 }
 
@@ -470,7 +222,7 @@ function GalleryImage ({ src }: { src: string }) {
   return (
     <>
       <button onClick={() => setOpen(true)} className='group block w-full'>
-        <div className='relative aspect-square overflow-hidden rounded-2xl border border-black/10 bg-white'>
+        <div className='relative aspect-square overflow-hidden rounded-2xl border border-white/15'>
           <img
             src={src}
             alt='Prepared food at Clarks'
@@ -480,13 +232,17 @@ function GalleryImage ({ src }: { src: string }) {
         </div>
       </button>
       {open && (
-        <div className='fixed inset-0 bg-black/70 z-50 flex items-center justify-center'>
+        <div
+          className='fixed inset-0 bg-black/70 z-50 flex items-center justify-center'
+          onClick={() => setOpen(false)}
+        >
           <div className='relative w-[90%] max-h-[90%]'>
             <button
               onClick={() => setOpen(false)}
-              className='absolute top-2 right-2 bg-brand text-white rounded-full px-3 py-1 shadow-lg'
+              className='absolute -top-3 -right-3 z-[1] grid h-9 w-9 place-items-center rounded-full bg-brand text-white shadow-lg'
+              aria-label='Close image'
             >
-              ✕
+              <IconClose className='h-4 w-4' />
             </button>
             <img
               src={src}
@@ -497,13 +253,5 @@ function GalleryImage ({ src }: { src: string }) {
         </div>
       )}
     </>
-  )
-}
-
-function PlaceholderEmpty ({ msg }: { msg: string }) {
-  return (
-    <div className='rounded-2xl border border-dashed border-black/20 bg-white p-6 text-center text-black/60'>
-      {msg}
-    </div>
   )
 }

--- a/ClarksPNS/src/pages/FoodBrand.tsx
+++ b/ClarksPNS/src/pages/FoodBrand.tsx
@@ -36,7 +36,7 @@ function boardsFor(assetKey: string): string[] {
 
 function Eyebrow({ children }: { children: React.ReactNode }) {
   return (
-    <div className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+    <div className="font-display tracking-wide text-xs uppercase text-brand">
       {children}
     </div>
   )
@@ -55,7 +55,7 @@ export default function FoodBrand() {
       <main className='w-full bg-white'>
         <SEO title='Menu not found — Clark’s Pump-N-Shop' robots='noindex,nofollow' />
         <div className='container mx-auto px-6 py-24 text-center md:px-10'>
-          <h1 className="font-['Oswald'] text-4xl font-bold text-black">
+          <h1 className="font-display text-4xl font-bold text-black">
             Menu not found
           </h1>
           <p className='mt-3 text-black/70'>
@@ -100,7 +100,7 @@ export default function FoodBrand() {
           <div className='flex flex-col items-start gap-6 py-8 md:flex-row md:items-center md:justify-between md:py-12'>
             <div>
               <Eyebrow>In-store kitchen</Eyebrow>
-              <h1 className="mt-1 font-['Oswald'] text-4xl font-bold leading-tight text-black md:text-6xl">
+              <h1 className="mt-1 font-display text-4xl font-bold leading-tight text-black md:text-6xl">
                 {brand.name}
               </h1>
               <div className='mt-4 h-1 w-40 rounded bg-brand' />
@@ -128,7 +128,7 @@ export default function FoodBrand() {
               key={section.title}
               className='rounded-2xl border border-black/10 brand-topline bg-white p-6 shadow-soft'
             >
-              <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+              <h2 className="font-display text-2xl font-bold text-black md:text-3xl">
                 {section.title}
               </h2>
               {section.note && (
@@ -172,10 +172,10 @@ export default function FoodBrand() {
       {/* Stores with this kitchen */}
       <section className='bg-brand brand-stripes py-12 text-white'>
         <div className='container mx-auto px-6 md:px-10'>
-          <div className="font-['Oswald'] tracking-wide text-xs uppercase text-white/70">
+          <div className="font-display tracking-wide text-xs uppercase text-white/70">
             Find it near you
           </div>
-          <h2 className="mt-1 font-['Oswald'] text-3xl font-bold md:text-4xl">
+          <h2 className="mt-1 font-display text-3xl font-bold md:text-4xl">
             {brand.name} is inside {stores.length} Clark’s location
             {stores.length === 1 ? '' : 's'}.
           </h2>
@@ -197,7 +197,7 @@ export default function FoodBrand() {
 
       {/* Other kitchens */}
       <section className='container mx-auto px-6 py-12 md:px-10'>
-        <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+        <h2 className="font-display text-2xl font-bold text-black md:text-3xl">
           More from our kitchens
         </h2>
         <div className='mt-4 flex flex-wrap gap-3'>
@@ -231,7 +231,7 @@ function StoreCard({ store }: { store: Store }) {
       onMouseLeave={e => { e.currentTarget.style.transform = '' }}
       className='group rounded-2xl border border-black/10 bg-white p-5 shadow-soft transition-[box-shadow,transform] duration-200 hover:shadow-md'
     >
-      <div className="font-['Oswald'] text-lg font-bold text-black group-hover:text-brand">
+      <div className="font-display text-lg font-bold text-black group-hover:text-brand">
         {store.name}
       </div>
       <div className='mt-1 text-sm text-black/70'>
@@ -256,7 +256,7 @@ function MenuBoards({ name, boards }: { name: string; boards: string[] }) {
 
   return (
     <section className='container mx-auto px-6 pb-4 md:px-10'>
-      <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+      <h2 className="font-display text-2xl font-bold text-black md:text-3xl">
         The menu board
       </h2>
       <div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2'>

--- a/ClarksPNS/src/pages/FoodBrand.tsx
+++ b/ClarksPNS/src/pages/FoodBrand.tsx
@@ -120,12 +120,13 @@ export default function FoodBrand() {
       </section>
 
       {/* Menu */}
-      <section className='container mx-auto px-6 py-10 md:px-10'>
+      <section className='brand-stripes-light'>
+      <div className='container mx-auto px-6 py-10 md:px-10'>
         <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
           {brand.sections.map(section => (
             <div
               key={section.title}
-              className='rounded-2xl border border-black/10 bg-white p-6 shadow-soft'
+              className='rounded-2xl border border-black/10 brand-topline bg-white p-6 shadow-soft'
             >
               <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
                 {section.title}
@@ -162,16 +163,19 @@ export default function FoodBrand() {
           Prices and availability may vary by location. Nutrition information
           available in store.
         </p>
+      </div>
       </section>
 
       {/* Menu boards */}
       {boards.length > 0 && <MenuBoards name={brand.name} boards={boards} />}
 
       {/* Stores with this kitchen */}
-      <section className='bg-surface-alt py-12'>
+      <section className='bg-brand brand-stripes py-12 text-white'>
         <div className='container mx-auto px-6 md:px-10'>
-          <Eyebrow>Find it near you</Eyebrow>
-          <h2 className="mt-1 font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+          <div className="font-['Oswald'] tracking-wide text-xs uppercase text-white/70">
+            Find it near you
+          </div>
+          <h2 className="mt-1 font-['Oswald'] text-3xl font-bold md:text-4xl">
             {brand.name} is inside {stores.length} Clark’s location
             {stores.length === 1 ? '' : 's'}.
           </h2>
@@ -183,7 +187,7 @@ export default function FoodBrand() {
           <div className='mt-8'>
             <Link
               to='/locations'
-              className='inline-flex items-center justify-center rounded-2xl bg-brand px-5 py-3 text-white transition-colors hover:bg-brand/90'
+              className='inline-flex items-center justify-center rounded-2xl bg-white px-5 py-3 font-semibold text-brand transition-transform hover:-translate-y-0.5'
             >
               See all locations
             </Link>
@@ -216,7 +220,16 @@ function StoreCard({ store }: { store: Store }) {
   return (
     <Link
       to={`/locations/${store.slug}`}
-      className='group rounded-2xl border border-black/10 bg-white p-5 shadow-soft transition-shadow hover:shadow-md'
+      onMouseMove={e => {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+        const el = e.currentTarget
+        const r = el.getBoundingClientRect()
+        const x = (e.clientX - r.left) / r.width - 0.5
+        const y = (e.clientY - r.top) / r.height - 0.5
+        el.style.transform = `perspective(900px) rotateY(${x * 5}deg) rotateX(${-y * 4}deg)`
+      }}
+      onMouseLeave={e => { e.currentTarget.style.transform = '' }}
+      className='group rounded-2xl border border-black/10 bg-white p-5 shadow-soft transition-[box-shadow,transform] duration-200 hover:shadow-md'
     >
       <div className="font-['Oswald'] text-lg font-bold text-black group-hover:text-brand">
         {store.name}

--- a/ClarksPNS/src/pages/Home.tsx
+++ b/ClarksPNS/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { DesktopHero } from '@/components/site/DesktopHero'
 import YourClarks from '@/components/site/YourClarks'
 import HometownCinema from '@/components/site/HometownCinema'
+import whiteLogo from '@/assets/images/Clarks PNS Logo Updated all white.png'
 import { SEO } from '@/lib/seo'
 
 // MobileHero images (keep as-is)
@@ -368,6 +369,24 @@ export default function Home () {
 
       {/* Cinematic hometowns band — real drone film + storefront showcase */}
       <HometownCinema />
+
+      {/* Tri-State family ribbon */}
+      <section aria-label='Family owned across the Tri-State' className='bg-brand'>
+        <div className='container mx-auto flex flex-col items-center gap-4 px-6 py-8 text-center text-white sm:flex-row sm:justify-between sm:text-left md:px-10'>
+          <img src={whiteLogo} alt='Clark’s Pump-N-Shop' className='h-12 w-auto sm:h-14' loading='lazy' />
+          <div>
+            <div className="font-['Oswald'] text-xl font-bold uppercase tracking-wide md:text-2xl">
+              Family owned & operated since 1976
+            </div>
+            <div className='mt-1 text-white/85'>
+              Rooted in Ashland — at home across Kentucky, Ohio & West Virginia.
+            </div>
+          </div>
+          <div className="font-['Oswald'] text-sm uppercase tracking-[0.25em] text-white/70">
+            KY · OH · WV
+          </div>
+        </div>
+      </section>
 
       {/* Rewards Phone Animation */}
       <section

--- a/ClarksPNS/src/pages/Home.tsx
+++ b/ClarksPNS/src/pages/Home.tsx
@@ -3,6 +3,9 @@ import React from 'react'
 import { DesktopHero } from '@/components/site/DesktopHero'
 import YourClarks from '@/components/site/YourClarks'
 import HometownCinema from '@/components/site/HometownCinema'
+import Tilt from '@/components/site/Tilt'
+import { FOOD_BRANDS } from '@/content/menus'
+import { allStores, namedKitchens } from '@/lib/stores'
 import whiteLogo from '@/assets/images/Clarks PNS Logo Updated all white.png'
 import { SEO } from '@/lib/seo'
 
@@ -11,6 +14,7 @@ import phone640 from '@/assets/images/phone-640.jpg'
 import phone960 from '@/assets/images/phone-960.jpg'
 import phone1440 from '@/assets/images/phone-1440.jpg'
 import champsLogo from '@/assets/images/champschickenlogo.png'
+import clarksMark from '@/assets/images/clarks-logo.png'
 import hangarLogo from '@/assets/images/Hangar54Logo_02-1.png'
 import jacksLogo from '@/assets/images/jacksdelilogo.webp'
 import cafeLogo from '@/assets/images/clarkscafelogo.webp'
@@ -513,18 +517,82 @@ export default function Home () {
         </div>
       </section>
 
+      {/* Food at Clarks */}
+      <section
+        aria-label='Food at Clarks'
+        className='relative bg-surface-alt brand-stripes-light py-12 md:py-20'
+      >
+        <div aria-hidden className='ghost-word ghost-word--blue text-center'>EAT</div>
+        <div className='container mx-auto px-6 md:px-10'>
+          <div className='max-w-3xl'>
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
+              Fuel up. Eat well.
+            </h2>
+            <p className='mt-2 text-black/70 text-base md:text-lg'>
+              Hot, fresh, and fast—right inside select locations.
+            </p>
+          </div>
+
+          <div className='relative mt-8 flex flex-wrap justify-center gap-6 [perspective:1400px]'>
+            {FOOD_PARTNERS.map(f => {
+              const kitchen = f.kitchenName && KITCHEN_COUNT[f.kitchenName]
+              const menuSlug = f.kitchenName ? MENU_SLUG[f.kitchenName] : undefined
+              return (
+                <Tilt key={f.name} max={8} className='w-full sm:w-[22rem]'>
+                  <article className='h-full rounded-2xl border border-black/10 brand-topline bg-white p-6 shadow-soft'>
+                    <div className='mb-4 flex h-12 items-center'>
+                      <img
+                        src={f.logo}
+                        alt={`${f.name} logo`}
+                        className='h-full w-auto object-contain'
+                      />
+                    </div>
+                    <h3 className='font-display text-2xl text-black'>{f.name}</h3>
+                    <p className='mt-1 text-black/70 text-sm'>{f.desc}</p>
+                    {kitchen ? (
+                      <p className='mt-2 font-display text-sm tracking-[0.08em] text-brand'>
+                        INSIDE {kitchen} STORES
+                      </p>
+                    ) : (
+                      <p className='mt-2 font-display text-sm tracking-[0.08em] text-black/50'>
+                        SELECT LOCATIONS
+                      </p>
+                    )}
+                    <div className='mt-4 flex flex-wrap gap-2'>
+                      {menuSlug && (
+                        <a
+                          href={`/food/${menuSlug}`}
+                          className='inline-flex items-center justify-center rounded-xl bg-brand px-4 py-2 text-white transition-all hover:bg-brand/90'
+                        >
+                          See the menu
+                        </a>
+                      )}
+                      <a
+                        href={menuSlug ? `/food/${menuSlug}#find` : '/locations'}
+                        className='inline-flex items-center justify-center rounded-xl border border-brand/40 px-4 py-2 text-brand transition-colors hover:bg-brand/5'
+                      >
+                        Find stores
+                      </a>
+                    </div>
+                  </article>
+                </Tilt>
+              )
+            })}
+          </div>
+        </div>
+      </section>
       {/* Follow Clarks — expandable social cards (updated embeds) */}
       <section
         aria-label='Follow Clarks'
-        className='py-12 md:py-20 bg-white'
+        className='py-10 md:py-14 bg-white border-t border-black/10'
         id='follow-clarks'
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
+            <h2 className='font-display text-xl md:text-2xl text-black/70'>
               Follow Clarks
             </h2>
-            <p className='mt-2 text-black text-base md:text-lg'>
+            <p className='mt-1 text-black/50 text-sm'>
               Deals, giveaways, and local highlights—tap a network to peek.
             </p>
           </div>
@@ -652,53 +720,6 @@ export default function Home () {
         </div>
       </section>
 
-      {/* Food at Clarks */}
-      <section
-        aria-label='Food at Clarks'
-        className='py-12 md:py-20 bg-neutral-50'
-      >
-        <div className='container mx-auto px-6 md:px-10'>
-          <div className='max-w-3xl'>
-            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
-              Fuel up. Eat well.
-            </h2>
-            <p className='mt-2 text-black/70 text-base md:text-lg'>
-              Hot, fresh, and fast—right inside select locations.
-            </p>
-          </div>
-
-          <div className='mt-8 flex flex-wrap justify-center gap-6'>
-            {FOOD_PARTNERS.map(f => (
-              <article
-                key={f.name}
-                className='rounded-2xl border border-black/10 bg-white p-6 hover:shadow-md transition-shadow w-full sm:w-[22rem] lg:w-[22rem]'
-              >
-                {/* Logo row */}
-                <div className='mb-4 h-12 flex items-center'>
-                  <img
-                    src={f.logo}
-                    alt={`${f.name} logo`}
-                    className='h-full w-auto object-contain'
-                  />
-                </div>
-
-                <h3 className="font-display text-xl font-bold text-black">
-                  {f.name}
-                </h3>
-                <p className='mt-2 text-black/70 text-sm'>{f.desc}</p>
-                <div className='mt-4'>
-                  <a
-                    href={f.href}
-                    className='inline-flex items-center justify-center rounded-xl px-4 py-2 bg-brand text-white hover:bg-brand/90 transition-all'
-                  >
-                    {f.cta}
-                  </a>
-                </div>
-              </article>
-            ))}
-          </div>
-        </div>
-      </section>
     </main>
   )
 }
@@ -726,16 +747,17 @@ function SocialButton ({
   )
 }
 
-const SOCIAL_LINKS = [
-  { name: 'Facebook', href: '#', icon: '👍' },
-  { name: 'Instagram', href: '#', icon: '📸' },
-  { name: 'TikTok', href: '#', icon: '🎵' },
-  { name: 'LinkedIn', href: '#', icon: '💼' }
-]
+const KITCHEN_COUNT: Record<string, number> = {}
+for (const st of allStores) {
+  for (const k of namedKitchens(st)) KITCHEN_COUNT[k] = (KITCHEN_COUNT[k] || 0) + 1
+}
+const MENU_SLUG: Record<string, string> = {}
+for (const b of FOOD_BRANDS) MENU_SLUG[b.kitchenName] = b.slug
 
 const FOOD_PARTNERS = [
   {
     name: 'Clarks Cafe',
+    kitchenName: "Clark's Café",
     desc: 'Breakfast sandwiches, pastries, and coffee.',
     href: '/locations?food=clarkscafe',
     cta: 'View Locations',
@@ -743,6 +765,7 @@ const FOOD_PARTNERS = [
   },
   {
     name: 'Krispy Krunchy Chicken',
+    kitchenName: 'Krispy Krunchy Chicken',
     desc: 'Louisiana-style chicken + biscuits.',
     href: '/locations?food=krispykrunchy',
     cta: 'View Locations',
@@ -750,6 +773,7 @@ const FOOD_PARTNERS = [
   },
   {
     name: 'Champs Chicken',
+    kitchenName: 'Champs Chicken',
     desc: 'Crispy tenders, sides, and sauces.',
     href: '/locations?food=champs',
     cta: 'View Locations',
@@ -757,6 +781,7 @@ const FOOD_PARTNERS = [
   },
   {
     name: 'Hangar 54 Pizza',
+    kitchenName: 'Hangar 54',
     desc: 'Slices and whole pies—perfectly melty.',
     href: '/locations?food=hangar',
     cta: 'View Locations',
@@ -772,9 +797,9 @@ const FOOD_PARTNERS = [
   {
     name: 'Grab-N-Go',
     desc: 'Quick bites, immediate satisfaction.',
-    href: '/locations?food=grabngo',
+    href: '/locations',
     cta: 'View Locations',
-    logo: kkcLogo
+    logo: clarksMark
   }
 ]
 

--- a/ClarksPNS/src/pages/Home.tsx
+++ b/ClarksPNS/src/pages/Home.tsx
@@ -186,7 +186,7 @@ function MonthlyPromotions ({
 
       <section
         aria-label='Monthly Promotions'
-        className='py-12 md:py-20 bg-neutral-50'
+        className='py-12 md:py-20 bg-surface-alt brand-stripes-light border-y border-black/10'
       >
         {/* Headings inside container */}
         <div className='container mx-auto px-6 md:px-10'>

--- a/ClarksPNS/src/pages/Home.tsx
+++ b/ClarksPNS/src/pages/Home.tsx
@@ -584,26 +584,32 @@ export default function Home () {
       {/* Follow Clarks — expandable social cards (updated embeds) */}
       <section
         aria-label='Follow Clarks'
-        className='py-10 md:py-14 bg-white border-t border-black/10'
+        className='relative py-10 md:py-14 bg-surface-alt brand-stripes-light border-t border-black/10 overflow-hidden'
         id='follow-clarks'
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className='font-display text-xl md:text-2xl text-black/70'>
-              Follow Clarks
+            <h2 className='font-display text-2xl md:text-3xl text-black'>
+              Follow the swoosh
             </h2>
-            <p className='mt-1 text-black/50 text-sm'>
-              Deals, giveaways, and local highlights—tap a network to peek.
+            <p className='mt-1 text-black/55 text-sm'>
+              Deals, giveaways, and hometown highlights — tap a card to peek
+              inside.
             </p>
           </div>
 
           <div className='mt-8 grid grid-cols-1 md:grid-cols-2 gap-6 text-black'>
             {/* Facebook — embedded timeline (unchanged) */}
-            <details className='group rounded-2xl border border-black/10 bg-white p-5 open:shadow-md'>
+            <details className='social-card group rounded-2xl border border-black/10 brand-topline bg-white p-5 open:shadow-md'>
               <summary className='cursor-pointer list-none flex items-center justify-between'>
                 <div className='flex items-center gap-3'>
-                  <img src={fbIcon} alt='' className='h-6 w-6' />
-                  <span className='font-semibold'>Facebook</span>
+                  <span
+                    className='social-chip grid h-11 w-11 place-items-center rounded-xl shadow-md'
+                    style={{ background: '#1877F2' }}
+                  >
+                    <img src={fbIcon} alt='' className='h-5 w-5 brightness-0 invert' />
+                  </span>
+                  <span className='font-display text-xl text-black'>Facebook</span>
                 </div>
                 <span className='ml-4 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-neutral-100 group-open:rotate-45 transition-transform'>
                   +
@@ -637,11 +643,16 @@ export default function Home () {
             </details>
 
             {/* Instagram — single reel */}
-            <details className='group rounded-2xl border border-black/10 bg-white p-5 open:shadow-md'>
+            <details className='social-card group rounded-2xl border border-black/10 brand-topline bg-white p-5 open:shadow-md'>
               <summary className='cursor-pointer list-none flex items-center justify-between'>
                 <div className='flex items-center gap-3'>
-                  <img src={igIcon} alt='' className='h-6 w-6' />
-                  <span className='font-semibold'>Instagram</span>
+                  <span
+                    className='social-chip grid h-11 w-11 place-items-center rounded-xl shadow-md'
+                    style={{ background: 'linear-gradient(45deg,#f09433,#e6683c,#dc2743,#cc2366,#bc1888)' }}
+                  >
+                    <img src={igIcon} alt='' className='h-5 w-5 brightness-0 invert' />
+                  </span>
+                  <span className='font-display text-xl text-black'>Instagram</span>
                 </div>
                 <span className='ml-4 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-neutral-100 group-open:rotate-45 transition-transform'>
                   +
@@ -664,11 +675,16 @@ export default function Home () {
             </details>
 
             {/* TikTok — single video */}
-            <details className='group rounded-2xl border border-black/10 bg-white p-5 open:shadow-md'>
+            <details className='social-card group rounded-2xl border border-black/10 brand-topline bg-white p-5 open:shadow-md'>
               <summary className='cursor-pointer list-none flex items-center justify-between'>
                 <div className='flex items-center gap-3'>
-                  <img src={ttIcon} alt='' className='h-6 w-6' />
-                  <span className='font-semibold'>TikTok</span>
+                  <span
+                    className='social-chip grid h-11 w-11 place-items-center rounded-xl shadow-md'
+                    style={{ background: '#0b153a' }}
+                  >
+                    <img src={ttIcon} alt='' className='h-5 w-5 brightness-0 invert' />
+                  </span>
+                  <span className='font-display text-xl text-black'>TikTok</span>
                 </div>
                 <span className='ml-4 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-neutral-100 group-open:rotate-45 transition-transform'>
                   +
@@ -690,11 +706,16 @@ export default function Home () {
             </details>
 
             {/* LinkedIn — single company post */}
-            <details className='group rounded-2xl border border-black/10 bg-white p-5 open:shadow-md'>
+            <details className='social-card group rounded-2xl border border-black/10 brand-topline bg-white p-5 open:shadow-md'>
               <summary className='cursor-pointer list-none flex items-center justify-between'>
                 <div className='flex items-center gap-3'>
-                  <img src={liIcon} alt='' className='h-6 w-6' />
-                  <span className='font-semibold'>LinkedIn</span>
+                  <span
+                    className='social-chip grid h-11 w-11 place-items-center rounded-xl shadow-md'
+                    style={{ background: '#0A66C2' }}
+                  >
+                    <img src={liIcon} alt='' className='h-5 w-5 brightness-0 invert' />
+                  </span>
+                  <span className='font-display text-xl text-black'>LinkedIn</span>
                 </div>
                 <span className='ml-4 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-neutral-100 group-open:rotate-45 transition-transform'>
                   +

--- a/ClarksPNS/src/pages/Home.tsx
+++ b/ClarksPNS/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 // import MobileHero from '@/components/site/MobileHero'
 import { DesktopHero } from '@/components/site/DesktopHero'
 import YourClarks from '@/components/site/YourClarks'
+import HometownCinema from '@/components/site/HometownCinema'
 import { SEO } from '@/lib/seo'
 
 // MobileHero images (keep as-is)
@@ -364,6 +365,9 @@ export default function Home () {
 
       {/* Your nearest Clark's — appears once the visitor shares location */}
       <YourClarks />
+
+      {/* Cinematic hometowns band — real drone film + storefront showcase */}
+      <HometownCinema />
 
       {/* Rewards Phone Animation */}
       <section

--- a/ClarksPNS/src/pages/Home.tsx
+++ b/ClarksPNS/src/pages/Home.tsx
@@ -191,7 +191,7 @@ function MonthlyPromotions ({
         {/* Headings inside container */}
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               {title}
             </h2>
             {subtitle && (
@@ -375,14 +375,14 @@ export default function Home () {
         <div className='container mx-auto flex flex-col items-center gap-4 px-6 py-8 text-center text-white sm:flex-row sm:justify-between sm:text-left md:px-10'>
           <img src={whiteLogo} alt='Clark’s Pump-N-Shop' className='h-12 w-auto sm:h-14' loading='lazy' />
           <div>
-            <div className="font-['Oswald'] text-xl font-bold uppercase tracking-wide md:text-2xl">
+            <div className="font-display text-xl font-bold uppercase tracking-wide md:text-2xl">
               Family owned & operated since 1976
             </div>
             <div className='mt-1 text-white/85'>
               Rooted in Ashland — at home across Kentucky, Ohio & West Virginia.
             </div>
           </div>
-          <div className="font-['Oswald'] text-sm uppercase tracking-[0.25em] text-white/70">
+          <div className="font-display text-sm uppercase tracking-[0.25em] text-white/70">
             KY · OH · WV
           </div>
         </div>
@@ -391,19 +391,19 @@ export default function Home () {
       {/* Rewards Phone Animation */}
       <section
         aria-label='Clarks Rewards Phone Demo'
-        className='py-12 md:py-20 bg-white border-y border-black/10'
+        className='band-night brand-stripes py-12 md:py-20 text-white'
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='grid grid-cols-1 lg:grid-cols-2 items-center gap-10'>
             <div className='order-2 lg:order-1'>
-              <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+              <h2 className="font-display text-3xl md:text-4xl font-bold">
                 Watch points stack—right in the app
               </h2>
-              <p className='mt-3 text-black/70 text-base md:text-lg max-w-prose'>
+              <p className='mt-3 text-white/80 text-base md:text-lg max-w-prose'>
                 Earn on every fill-up, coffee, and snack. Track your balance and
                 redeem at the pump or register in a couple of taps.
               </p>
-              <ul className='mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-black/70'>
+              <ul className='mt-6 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm text-white/80'>
                 <li className='flex items-start gap-2'>
                   <span className='mt-1 inline-block h-2 w-2 rounded-full bg-brand' />{' '}
                   Members-only weekly Boosts
@@ -482,7 +482,7 @@ export default function Home () {
             <div className='container mx-auto h-full px-6 md:px-10'>
               <div className='flex h-full items-center'>
                 <div className='inline-flex flex-col gap-4 md:gap-6 max-w-[720px]'>
-                  <h2 className="font-['Oswald'] text-3xl md:text-5xl font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.35)]">
+                  <h2 className="font-display text-3xl md:text-5xl font-bold text-white drop-shadow-[0_2px_12px_rgba(0,0,0,0.35)]">
                     Rodney the Rewards Ranger
                   </h2>
                   <p className='text-white/95 text-base md:text-xl drop-shadow-[0_2px_8px_rgba(0,0,0,0.35)] max-w-prose'>
@@ -521,7 +521,7 @@ export default function Home () {
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               Follow Clarks
             </h2>
             <p className='mt-2 text-black text-base md:text-lg'>
@@ -659,7 +659,7 @@ export default function Home () {
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               Fuel up. Eat well.
             </h2>
             <p className='mt-2 text-black/70 text-base md:text-lg'>
@@ -682,7 +682,7 @@ export default function Home () {
                   />
                 </div>
 
-                <h3 className="font-['Oswald'] text-xl font-bold text-black">
+                <h3 className="font-display text-xl font-bold text-black">
                   {f.name}
                 </h3>
                 <p className='mt-2 text-black/70 text-sm'>{f.desc}</p>

--- a/ClarksPNS/src/pages/Locations.tsx
+++ b/ClarksPNS/src/pages/Locations.tsx
@@ -266,7 +266,7 @@ const GOOGLE_KEY = (
 )?.trim()
 
 const mapContainerStyle = { width: '100%', height: '100%' } as const
-const initialCenter: LatLng = { lat: 39.5, lng: -98.35 } // US fallback
+const initialCenter: LatLng = { lat: 38.35, lng: -83.6 } // Tri-State heart
 
 // --- utilities ---
 function fullAddress (s: StoreEntry): string {
@@ -866,7 +866,7 @@ function MapCanvas ({
     <GoogleMap
       mapContainerStyle={mapContainerStyle}
       center={center}
-      zoom={userPoint ? 9 : 5}
+      zoom={userPoint ? 9 : 7}
     >
       {/* User pin */}
       {userPoint && (

--- a/ClarksPNS/src/pages/Locations.tsx
+++ b/ClarksPNS/src/pages/Locations.tsx
@@ -5,6 +5,7 @@ import { SEO } from '@/lib/seo'
 import { buildLocationsItemList } from '@/lib/locations-schema'
 import { allStores, formatPhone } from '@/lib/stores'
 import BeaconMap from '@/components/site/BeaconMap'
+import RoadTrip from '@/components/site/RoadTrip'
 
 // Map a store id (key in stores.geocoded.json) to its store-page slug.
 const SLUG_BY_ID: Record<string, string> = Object.fromEntries(
@@ -563,6 +564,8 @@ export default function Locations () {
             <div className='mt-8'>
               <BeaconMap />
             </div>
+
+            <RoadTrip />
           </div>
         </div>
       </section>

--- a/ClarksPNS/src/pages/Locations.tsx
+++ b/ClarksPNS/src/pages/Locations.tsx
@@ -499,21 +499,14 @@ export default function Locations () {
       />
     <main className='w-full overflow-x-clip bg-white -mt-5'>
       {/* Header / Search */}
-      <section className='relative isolate w-full bg-gradient-to-br from-white via-white to-neutral-50'>
-        <div
-          aria-hidden
-          className='pointer-events-none absolute inset-0 opacity-[0.07]'
-          style={{
-            background:
-              'repeating-linear-gradient(135deg, var(--tw-gradient-to) 0 2px, transparent 2px 22px)'
-          }}
-        />
+      <section className='band-night brand-stripes relative isolate w-full text-white'>
+        <div aria-hidden className='ghost-word ghost-word--light text-center'>FIND US</div>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='py-10 md:py-16'>
-            <h1 className="font-['Oswald'] text-4xl md:text-6xl font-extrabold text-black leading-tight">
+            <h1 className="font-display text-4xl md:text-6xl font-extrabold leading-tight">
               Find a Clarks near you
             </h1>
-            <p className='mt-2 text-black/70 text-lg md:text-xl max-w-prose'>
+            <p className='mt-2 text-white/80 text-lg md:text-xl max-w-prose'>
               To see nearby locations and available amenities, enter an address
               or select “Use My Location.”
             </p>
@@ -576,7 +569,7 @@ export default function Locations () {
             {/* Results list (mobile after map) */}
             <div className='lg:col-span-5 order-2 lg:order-1'>
               <div className='flex items-center justify-between'>
-                <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+                <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                   Nearby stores
                 </h2>
                 <div className='flex items-center gap-3'>
@@ -652,7 +645,7 @@ export default function Locations () {
                   return (
                     <React.Fragment key={id}>
                     {stateHeading && (
-                      <h3 className="pt-4 font-['Oswald'] text-xl font-bold text-brand uppercase tracking-wide">
+                      <h3 className="pt-4 font-display text-xl font-bold text-brand uppercase tracking-wide">
                         {stateHeading}
                       </h3>
                     )}
@@ -670,7 +663,7 @@ export default function Locations () {
                     >
                       <div className='flex items-start justify-between gap-3'>
                         <div>
-                          <div className="font-['Oswald'] font-bold text-lg text-black">
+                          <div className="font-display font-bold text-lg text-black">
                             {SLUG_BY_ID[id] ? (
                               <Link
                                 to={`/locations/${SLUG_BY_ID[id]}`}
@@ -1002,7 +995,7 @@ function FilterPanel ({
   return (
     <div className='space-y-3'>
       <div className='flex items-center justify-between'>
-        <div className="font-['Oswald'] text-lg font-bold">Filter</div>
+        <div className="font-display text-lg font-bold">Filter</div>
         <button
           type='button'
           onClick={clearFilters}

--- a/ClarksPNS/src/pages/Locations.tsx
+++ b/ClarksPNS/src/pages/Locations.tsx
@@ -465,7 +465,7 @@ export default function Locations () {
         .filter(r => matchesFilters(r.entry))
         .sort(
           (a, b) =>
-            (a.entry.state || '').localeCompare(b.entry.state || '') ||
+            (a.entry.state || '').toUpperCase().localeCompare((b.entry.state || '').toUpperCase()) ||
             (a.entry.city || '').localeCompare(b.entry.city || '') ||
             (a.entry.name || '').localeCompare(b.entry.name || '')
         )
@@ -625,7 +625,21 @@ export default function Locations () {
 
               {/* Results */}
               <div className='mt-4 space-y-4'>
-                {results.map(r => {
+                {results.map((r, i) => {
+                  const stateChanged =
+                    !userPoint &&
+                    (i === 0 ||
+                      (results[i - 1].entry.state || '').toUpperCase() !==
+                        (r.entry.state || '').toUpperCase())
+                  const STATE_NAME: Record<string, string> = {
+                    KY: 'Kentucky',
+                    OH: 'Ohio',
+                    WV: 'West Virginia'
+                  }
+                  const stateHeading = stateChanged
+                    ? STATE_NAME[(r.entry.state || '').toUpperCase()] ||
+                      r.entry.state
+                    : null
                   const { id, entry, distance, addr } = r
                   const a = { ...DEFAULT_AMENITIES, ...(entry.amenities ?? {}) }
                   const f = { ...DEFAULT_FOOD, ...(entry.food ?? {}) }
@@ -636,8 +650,13 @@ export default function Locations () {
                   ).filter(k => !!a[k as keyof Amenities])
 
                   return (
+                    <React.Fragment key={id}>
+                    {stateHeading && (
+                      <h3 className="pt-4 font-['Oswald'] text-xl font-bold text-brand uppercase tracking-wide">
+                        {stateHeading}
+                      </h3>
+                    )}
                     <article
-                      key={id}
                       className='rounded-2xl border border-black/10 bg-white p-5 hover:shadow-md transition-shadow'
                     >
                       <div className='flex items-start justify-between gap-3'>
@@ -749,6 +768,7 @@ export default function Locations () {
                         </button>
                       </div>
                     </article>
+                    </React.Fragment>
                   )
                 })}
 

--- a/ClarksPNS/src/pages/Locations.tsx
+++ b/ClarksPNS/src/pages/Locations.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { SEO } from '@/lib/seo'
 import { buildLocationsItemList } from '@/lib/locations-schema'
 import { allStores, formatPhone } from '@/lib/stores'
+import BeaconMap from '@/components/site/BeaconMap'
 
 // Map a store id (key in stores.geocoded.json) to its store-page slug.
 const SLUG_BY_ID: Record<string, string> = Object.fromEntries(
@@ -558,6 +559,10 @@ export default function Locations () {
                 </p>
               )}
             </form>
+
+            <div className='mt-8'>
+              <BeaconMap />
+            </div>
           </div>
         </div>
       </section>

--- a/ClarksPNS/src/pages/Locations.tsx
+++ b/ClarksPNS/src/pages/Locations.tsx
@@ -624,7 +624,7 @@ export default function Locations () {
               )}
 
               {/* Results */}
-              <div className='mt-4 space-y-4'>
+              <div className='mt-4 space-y-4 [perspective:1400px]'>
                 {results.map((r, i) => {
                   const stateChanged =
                     !userPoint &&
@@ -657,7 +657,16 @@ export default function Locations () {
                       </h3>
                     )}
                     <article
-                      className='rounded-2xl border border-black/10 bg-white p-5 hover:shadow-md transition-shadow'
+                      className='rounded-2xl border border-black/10 bg-white p-5 hover:shadow-md transition-[box-shadow,transform] duration-200 [transform-style:preserve-3d]'
+                      onMouseMove={e => {
+                        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
+                        const el = e.currentTarget
+                        const r = el.getBoundingClientRect()
+                        const x = (e.clientX - r.left) / r.width - 0.5
+                        const y = (e.clientY - r.top) / r.height - 0.5
+                        el.style.transform = `rotateY(${x * 4}deg) rotateX(${-y * 3}deg)`
+                      }}
+                      onMouseLeave={e => { e.currentTarget.style.transform = '' }}
                     >
                       <div className='flex items-start justify-between gap-3'>
                         <div>

--- a/ClarksPNS/src/pages/Privacy.tsx
+++ b/ClarksPNS/src/pages/Privacy.tsx
@@ -13,11 +13,11 @@ export default function Privacy() {
           }}
         />
         <div className='container mx-auto px-6 md:px-10 py-14 md:py-16 relative z-10'>
-          <p className="font-['Oswald'] tracking-wide text-xs uppercase text-white/80">
+          <p className="font-display tracking-wide text-xs uppercase text-white/80">
             Clark&apos;s Rewards
           </p>
 
-          <h1 className="mt-2 font-['Oswald'] text-3xl md:text-5xl font-bold leading-tight">
+          <h1 className="mt-2 font-display text-3xl md:text-5xl font-bold leading-tight">
             Privacy Policy
           </h1>
           <p className="mt-2 text-sm text-white/80">
@@ -34,7 +34,7 @@ export default function Privacy() {
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-4xl space-y-10 text-black/80'>
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 1. Information We Collect
               </h2>
               <p className='mt-3 leading-7'>
@@ -56,7 +56,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 2. How We Use Your Information
               </h2>
               <p className='mt-3 leading-7'>
@@ -73,7 +73,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 3. How We Share Information
               </h2>
               <p className='mt-3 leading-7'>
@@ -95,7 +95,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 4. Marketing & SMS Communications
               </h2>
               <p className='mt-3 leading-7'>
@@ -111,7 +111,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 5. Data Security
               </h2>
               <p className='mt-3 leading-7'>
@@ -124,7 +124,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 6. Data Retention
               </h2>
               <p className='mt-3 leading-7'>
@@ -134,7 +134,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 7. Your Rights & Choices
               </h2>
               <p className='mt-3 leading-7'>
@@ -155,7 +155,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 8. Children&apos;s Privacy
               </h2>
               <p className='mt-3 leading-7'>
@@ -166,7 +166,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 9. Changes to This Policy
               </h2>
               <p className='mt-3 leading-7'>
@@ -176,7 +176,7 @@ export default function Privacy() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 10. Contact Us
               </h2>
               <p className='mt-3 leading-7'>

--- a/ClarksPNS/src/pages/Scholarship.tsx
+++ b/ClarksPNS/src/pages/Scholarship.tsx
@@ -21,10 +21,10 @@ export default function Scholarship() {
       <section className='relative isolate -mt-[16px] bg-gradient-to-br from-white via-white to-neutral-50 md:-mt-[20px]'>
         <div className='container mx-auto grid grid-cols-1 items-center gap-10 px-6 py-14 md:px-10 md:py-20 lg:grid-cols-12'>
           <div className='lg:col-span-7'>
-            <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-brand">
+            <div className="font-display text-xs uppercase tracking-[0.3em] text-brand">
               The Clark legacy
             </div>
-            <h1 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight text-black md:text-6xl">
+            <h1 className="mt-2 font-display text-4xl font-bold leading-tight text-black md:text-6xl">
               For Rodney.
               <br />
               For the next generation.
@@ -57,7 +57,7 @@ export default function Scholarship() {
           <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
             <Tilt max={4}>
             <div className='rounded-2xl border border-black/10 brand-topline bg-white p-8 shadow-soft'>
-              <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+              <h2 className="font-display text-2xl font-bold text-black md:text-3xl">
                 Clark Family Scholarship
               </h2>
               <p className='mt-3 text-black/70'>
@@ -78,7 +78,7 @@ export default function Scholarship() {
             </Tilt>
             <Tilt max={4}>
             <div className='rounded-2xl border border-black/10 brand-topline bg-white p-8 shadow-soft'>
-              <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+              <h2 className="font-display text-2xl font-bold text-black md:text-3xl">
                 Rodney Clark Memorial Scholarship
               </h2>
               <p className='mt-3 text-black/70'>
@@ -98,7 +98,8 @@ export default function Scholarship() {
       </section>
 
       {/* Golf outing */}
-      <section className='container mx-auto px-6 py-12 md:px-10'>
+      <section className='bg-brand brand-stripes py-12 text-white'>
+        <div className='container mx-auto px-6 md:px-10'>
         <div className='grid grid-cols-1 items-center gap-10 lg:grid-cols-12'>
           <div className='lg:col-span-4'>
             <img
@@ -109,10 +110,10 @@ export default function Scholarship() {
             />
           </div>
           <div className='lg:col-span-8'>
-            <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+            <h2 className="font-display text-3xl font-bold md:text-4xl">
               The Rodney Clark Memorial Golf Outing
             </h2>
-            <p className='mt-3 max-w-prose text-black/70'>
+            <p className='mt-3 max-w-prose text-white/85'>
               Once a year the region shows up, tees off, and funds the next
               class of scholarships. The 2026 outing is played at the Keene
               Trace Champions Course — sponsorships and foursomes available.
@@ -121,11 +122,12 @@ export default function Scholarship() {
               href={golfPdf}
               target='_blank'
               rel='noreferrer'
-              className='mt-5 inline-flex items-center justify-center rounded-2xl border border-brand px-5 py-3 font-medium text-brand transition-colors hover:bg-brand/5'
+              className='mt-5 inline-flex items-center justify-center rounded-2xl bg-white px-5 py-3 font-semibold text-brand transition-transform hover:-translate-y-0.5'
             >
               2026 outing details (PDF)
             </a>
           </div>
+        </div>
         </div>
       </section>
     </main>

--- a/ClarksPNS/src/pages/Scholarship.tsx
+++ b/ClarksPNS/src/pages/Scholarship.tsx
@@ -1,6 +1,7 @@
 // The Rodney Clark legacy — scholarships and the memorial golf outing.
 // Also reclaims /scholarship, a URL Google still indexes from the old site.
 import { SEO } from '@/lib/seo'
+import Tilt from '@/components/site/Tilt'
 
 import rodneyPhoto from '@/assets/images/Charity/Rodney_Clark.jpg'
 import scrambleLogo from '@/assets/images/Charity/scramble/scrambleLogo.png'
@@ -51,10 +52,11 @@ export default function Scholarship() {
       </section>
 
       {/* The two scholarships */}
-      <section className='bg-surface-alt py-12'>
+      <section className='bg-surface-alt brand-stripes-light py-12'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
-            <div className='rounded-2xl border border-black/10 bg-white p-8 shadow-soft'>
+            <Tilt max={4}>
+            <div className='rounded-2xl border border-black/10 brand-topline bg-white p-8 shadow-soft'>
               <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
                 Clark Family Scholarship
               </h2>
@@ -73,7 +75,9 @@ export default function Scholarship() {
                 Download the application
               </a>
             </div>
-            <div className='rounded-2xl border border-black/10 bg-white p-8 shadow-soft'>
+            </Tilt>
+            <Tilt max={4}>
+            <div className='rounded-2xl border border-black/10 brand-topline bg-white p-8 shadow-soft'>
               <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
                 Rodney Clark Memorial Scholarship
               </h2>
@@ -88,6 +92,7 @@ export default function Scholarship() {
                 outing raises funds in his honor.
               </p>
             </div>
+            </Tilt>
           </div>
         </div>
       </section>

--- a/ClarksPNS/src/pages/Scholarship.tsx
+++ b/ClarksPNS/src/pages/Scholarship.tsx
@@ -1,0 +1,128 @@
+// The Rodney Clark legacy — scholarships and the memorial golf outing.
+// Also reclaims /scholarship, a URL Google still indexes from the old site.
+import { SEO } from '@/lib/seo'
+
+import rodneyPhoto from '@/assets/images/Charity/Rodney_Clark.jpg'
+import scrambleLogo from '@/assets/images/Charity/scramble/scrambleLogo.png'
+import golfPdf from '@/assets/files/2026 Rodney Clark Memorial Golf Outing - Keene Trace Champions Course 2026.pdf'
+import appPdf from '@/assets/files/2026 Scholarship Application (Central) (01226829x9F876) (1).PDF'
+
+export default function Scholarship() {
+  return (
+    <main className='w-full overflow-x-clip bg-white'>
+      <SEO
+        title='Scholarships — Clark’s Pump-N-Shop'
+        description='The Clark Family Scholarship and the Rodney Clark Memorial Scholarship — investing in students across Kentucky, Ohio, and West Virginia.'
+        path='/scholarship'
+      />
+
+      {/* Hero */}
+      <section className='relative isolate -mt-[16px] bg-gradient-to-br from-white via-white to-neutral-50 md:-mt-[20px]'>
+        <div className='container mx-auto grid grid-cols-1 items-center gap-10 px-6 py-14 md:px-10 md:py-20 lg:grid-cols-12'>
+          <div className='lg:col-span-7'>
+            <div className="font-['Oswald'] text-xs uppercase tracking-[0.3em] text-brand">
+              The Clark legacy
+            </div>
+            <h1 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight text-black md:text-6xl">
+              For Rodney.
+              <br />
+              For the next generation.
+            </h1>
+            <p className='mt-4 max-w-prose text-lg text-black/70'>
+              When Rodney Clark passed in 2016, his family turned grief into
+              a promise: help the young people of this region build their
+              future. Today that promise funds real degrees, real trades,
+              and real starts.
+            </p>
+          </div>
+          <div className='lg:col-span-5'>
+            <figure className='mx-auto max-w-[380px]'>
+              <img
+                src={rodneyPhoto}
+                alt='Rodney Clark'
+                className='w-full rounded-2xl border border-black/10 object-cover shadow-soft'
+              />
+              <figcaption className='mt-2 text-center text-sm text-black/50'>
+                Rodney Clark
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </section>
+
+      {/* The two scholarships */}
+      <section className='bg-surface-alt py-12'>
+        <div className='container mx-auto px-6 md:px-10'>
+          <div className='grid grid-cols-1 gap-6 lg:grid-cols-2'>
+            <div className='rounded-2xl border border-black/10 bg-white p-8 shadow-soft'>
+              <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+                Clark Family Scholarship
+              </h2>
+              <p className='mt-3 text-black/70'>
+                A $2,000 annual scholarship for students enrolled in a two-
+                to four-year college, university, trade school, or
+                vocational program. Built for the region we serve — because
+                a start close to home still counts.
+              </p>
+              <a
+                href={appPdf}
+                target='_blank'
+                rel='noreferrer'
+                className='mt-5 inline-flex items-center justify-center rounded-2xl bg-brand px-5 py-3 text-white transition-colors hover:bg-brand/90'
+              >
+                Download the application
+              </a>
+            </div>
+            <div className='rounded-2xl border border-black/10 bg-white p-8 shadow-soft'>
+              <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">
+                Rodney Clark Memorial Scholarship
+              </h2>
+              <p className='mt-3 text-black/70'>
+                In partnership with Ashland Community and Technical College,
+                Rodney’s scholarship carries his name forward — an endowment
+                built by his family, our stores, and this community, funding
+                students year after year.
+              </p>
+              <p className='mt-3 text-black/70'>
+                General donations are welcomed, and the annual memorial golf
+                outing raises funds in his honor.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Golf outing */}
+      <section className='container mx-auto px-6 py-12 md:px-10'>
+        <div className='grid grid-cols-1 items-center gap-10 lg:grid-cols-12'>
+          <div className='lg:col-span-4'>
+            <img
+              src={scrambleLogo}
+              alt='Rodney Clark Memorial Golf Outing'
+              className='mx-auto w-full max-w-[300px]'
+              loading='lazy'
+            />
+          </div>
+          <div className='lg:col-span-8'>
+            <h2 className="font-['Oswald'] text-3xl font-bold text-black md:text-4xl">
+              The Rodney Clark Memorial Golf Outing
+            </h2>
+            <p className='mt-3 max-w-prose text-black/70'>
+              Once a year the region shows up, tees off, and funds the next
+              class of scholarships. The 2026 outing is played at the Keene
+              Trace Champions Course — sponsorships and foursomes available.
+            </p>
+            <a
+              href={golfPdf}
+              target='_blank'
+              rel='noreferrer'
+              className='mt-5 inline-flex items-center justify-center rounded-2xl border border-brand px-5 py-3 font-medium text-brand transition-colors hover:bg-brand/5'
+            >
+              2026 outing details (PDF)
+            </a>
+          </div>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/ClarksPNS/src/pages/Sponsorship.tsx
+++ b/ClarksPNS/src/pages/Sponsorship.tsx
@@ -27,11 +27,11 @@ const Card = ({
 }) => (
   <article className='rounded-2xl border border-black/10 bg-white p-6 shadow-sm'>
     {eyebrow && (
-      <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">
+      <p className="font-display tracking-wide text-xs uppercase text-brand">
         {eyebrow}
       </p>
     )}
-    <h3 className="mt-1 font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+    <h3 className="mt-1 font-display text-2xl md:text-3xl font-bold text-black">
       {title}
     </h3>
     <div className='prose prose-neutral mt-3 max-w-none text-black/80'>
@@ -149,10 +149,10 @@ export default function SponsorshipsFeatured () {
       <section className='relative isolate bg-brand text-white'>
         <div className='container mx-auto grid md:grid-cols-12 gap-8 px-6 md:px-10 py-14 md:py-16 items-center'>
           <div className='md:col-span-7'>
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-white/80">
+            <p className="font-display tracking-wide text-xs uppercase text-white/80">
               Community Sponsorships
             </p>
-            <h1 className="mt-2 font-['Oswald'] text-3xl md:text-5xl font-bold leading-tight">
+            <h1 className="mt-2 font-display text-3xl md:text-5xl font-bold leading-tight">
               Backing local schools, teams, and community events
             </h1>
             <p className='mt-3 text-white/90 max-w-prose'>
@@ -308,7 +308,7 @@ export default function SponsorshipsFeatured () {
         className='py-12 md:py-16 bg-white border-t border-black/10'
       >
         <div className='container mx-auto px-6 md:px-10 text-center'>
-          <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+          <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
             Want to partner with Clark’s?
           </h2>
           <p className='mt-3 text-black/70'>

--- a/ClarksPNS/src/pages/Sponsorship_1.tsx
+++ b/ClarksPNS/src/pages/Sponsorship_1.tsx
@@ -28,9 +28,9 @@ const Card = ({
 }) => (
   <article className="rounded-2xl border border-black/10 bg-white p-6 shadow-sm">
     {eyebrow && (
-      <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">{eyebrow}</p>
+      <p className="font-display tracking-wide text-xs uppercase text-brand">{eyebrow}</p>
     )}
-    <h3 className="mt-1 font-['Oswald'] text-2xl md:text-3xl font-bold text-black">{title}</h3>
+    <h3 className="mt-1 font-display text-2xl md:text-3xl font-bold text-black">{title}</h3>
     <div className="prose prose-neutral mt-3 max-w-none text-black/80">{children}</div>
     {cta && (
       <div className="mt-5 flex flex-wrap gap-3">
@@ -161,8 +161,8 @@ export default function SponsorshipsPage() {
       <section className="relative isolate bg-brand text-white">
         <div className="container mx-auto grid md:grid-cols-12 gap-8 px-6 md:px-10 py-14 md:py-16 items-center">
           <div className="md:col-span-7">
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-white/80">Community Sponsorships</p>
-            <h1 className="mt-2 font-['Oswald'] text-3xl md:text-5xl font-bold leading-tight">
+            <p className="font-display tracking-wide text-xs uppercase text-white/80">Community Sponsorships</p>
+            <h1 className="mt-2 font-display text-3xl md:text-5xl font-bold leading-tight">
               Backing local schools, teams, and community events
             </h1>
             <p className="mt-3 text-white/90 max-w-prose">
@@ -207,8 +207,8 @@ export default function SponsorshipsPage() {
       <section id="high-school" className="py-12 md:py-16 bg-white">
         <div className="container mx-auto px-6 md:px-10">
           <div className="max-w-3xl">
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">Varsity & JV</p>
-            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">High School Partnerships</h2>
+            <p className="font-display tracking-wide text-xs uppercase text-brand">Varsity & JV</p>
+            <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">High School Partnerships</h2>
             <p className="mt-3 text-black/70">
               Signage, uniforms, equipment, and travel support—customized for each athletic department’s needs.
             </p>
@@ -231,8 +231,8 @@ export default function SponsorshipsPage() {
       <section id="youth" className="py-12 md:py-16 bg-white">
         <div className="container mx-auto px-6 md:px-10">
           <div className="max-w-3xl">
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">Ages 5–14</p>
-            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">Youth Sports</h2>
+            <p className="font-display tracking-wide text-xs uppercase text-brand">Ages 5–14</p>
+            <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">Youth Sports</h2>
             <p className="mt-3 text-black/70">
               Lowering barriers to play with registration scholarships, equipment drives, and field improvements.
             </p>
@@ -255,8 +255,8 @@ export default function SponsorshipsPage() {
       <section id="community" className="py-12 md:py-16 bg-white">
         <div className="container mx-auto px-6 md:px-10">
           <div className="max-w-3xl">
-            <p className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">Festivals & Drives</p>
-            <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">Community Events</h2>
+            <p className="font-display tracking-wide text-xs uppercase text-brand">Festivals & Drives</p>
+            <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">Community Events</h2>
             <p className="mt-3 text-black/70">
               Partnering with chambers, nonprofits, and civic groups to bring people together and give back.
             </p>
@@ -279,7 +279,7 @@ export default function SponsorshipsPage() {
       <section id="become-a-sponsor" className="py-12 md:py-16 bg-white border-y border-black/10">
         <div className="container mx-auto px-6 md:px-10 grid lg:grid-cols-12 gap-10 items-start justify-center text-center">
           <div className="lg:col-span-7">
-            <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">Interested in a sponsorship?</h2>
+            <h2 className="font-display text-2xl md:text-3xl font-bold text-black">Interested in a sponsorship?</h2>
             <p className="mt-3 text-black/70">
               Schools, coaches, boosters, and community organizers—tell us about your program and how we can help.
             </p>
@@ -290,7 +290,7 @@ export default function SponsorshipsPage() {
           </div>
 
           <div className="lg:col-span-5 text-left lg:text-center">
-            <h3 className="font-['Oswald'] text-xl md:text-2xl font-bold text-black">Sponsorship guidelines</h3>
+            <h3 className="font-display text-xl md:text-2xl font-bold text-black">Sponsorship guidelines</h3>
             <ul className="mt-3 space-y-2 text-sm text-black/70">
               <li>• Priority for schools/organizations near Clark’s locations in KY & OH.</li>
               <li>• Preference for safety, education, and youth development programs.</li>

--- a/ClarksPNS/src/pages/StoreDetail.tsx
+++ b/ClarksPNS/src/pages/StoreDetail.tsx
@@ -4,6 +4,8 @@ import { Link, useParams } from 'react-router-dom'
 import { SEO } from '@/lib/seo'
 import FindUsMap from '@/components/site/FindUsMap'
 import Forecourt3D from '@/components/site/Forecourt3D'
+import ColdSnapNote from '@/components/site/ColdSnapNote'
+import { track } from '@/lib/track'
 import StoreGallery from '@/components/site/StoreGallery'
 import storeMedia from '@/content/store-media.json'
 import { FOOD_BRANDS } from '@/content/menus'
@@ -15,6 +17,7 @@ import {
   getStoreBySlug,
   namedKitchens,
   nearbyStores,
+  ogImageUrl,
   openNow,
   priceCheckHref,
   storeJsonLd,
@@ -120,6 +123,7 @@ export default function StoreDetail() {
   return (
     <>
       <SEO
+        image={MEDIA[store.slug]?.image ? ogImageUrl(store) : undefined}
         title={`${store.name} — Clark’s Pump-N-Shop | ${store.city}, ${store.state}`}
         description={`Clark’s Pump-N-Shop in ${store.city}, ${store.state}: hours, fuel, ${
           kitchens.length ? kitchens.join(', ') + ', ' : ''
@@ -156,6 +160,7 @@ export default function StoreDetail() {
                   href={directionsHref(store)}
                   target='_blank'
                   rel='noreferrer'
+                  onClick={() => track('directions_click', { store: store.slug })}
                   className='inline-flex items-center justify-center rounded-2xl bg-brand px-5 py-3 text-base font-medium text-white transition-opacity hover:opacity-95'
                 >
                   Get Directions
@@ -163,6 +168,7 @@ export default function StoreDetail() {
                 {store.phone && (
                   <a
                     href={`tel:${store.phone.replace(/[^0-9]/g, '')}`}
+                    onClick={() => track('call_click', { store: store.slug })}
                     className='inline-flex items-center justify-center rounded-2xl border border-brand px-5 py-3 text-base font-medium text-brand transition-colors hover:bg-brand/5'
                   >
                     Call {store.phone}
@@ -202,6 +208,7 @@ export default function StoreDetail() {
               Check today’s price ↗
             </a>
           </div>
+          {store.amenities?.kerosene && <ColdSnapNote store={store} />}
         </section>
 
         {/* Content columns */}

--- a/ClarksPNS/src/pages/StoreDetail.tsx
+++ b/ClarksPNS/src/pages/StoreDetail.tsx
@@ -29,10 +29,10 @@ type Media = {
 }
 const MEDIA = storeMedia as Record<string, Media>
 
-// Matches the site's eyebrow style: font-['Oswald'] tracking-wide text-xs uppercase text-brand
+// Matches the site's eyebrow style: font-display tracking-wide text-xs uppercase text-brand
 function Eyebrow({ children, light = false }: { children: ReactNode; light?: boolean }) {
   return (
-    <div className={`font-['Oswald'] tracking-wide text-xs uppercase ${light ? 'text-white/80' : 'text-brand'}`}>
+    <div className={`font-display tracking-wide text-xs uppercase ${light ? 'text-white/80' : 'text-brand'}`}>
       {children}
     </div>
   )
@@ -90,7 +90,7 @@ export default function StoreDetail() {
       <>
         <SEO title='Location not found — Clark’s Pump-N-Shop' robots='noindex,nofollow' />
         <main className='container mx-auto px-6 py-24 text-center md:px-10'>
-          <h1 className="font-['Oswald'] text-4xl font-bold text-black">We can’t find that location</h1>
+          <h1 className="font-display text-4xl font-bold text-black">We can’t find that location</h1>
           <p className='mt-3 text-black/70'>Let’s get you back to the map.</p>
           <Link to='/locations' className='mt-6 inline-flex rounded-2xl bg-brand px-5 py-3 text-white hover:opacity-95'>
             Find a Location
@@ -142,7 +142,7 @@ export default function StoreDetail() {
           <div className='grid grid-cols-1 gap-8 py-8 lg:grid-cols-12 lg:py-10'>
             <div className='lg:col-span-7'>
               <Eyebrow>Store #{store.id} · {store.city}, {store.state}</Eyebrow>
-              <h1 className="mt-2 font-['Oswald'] text-4xl font-bold leading-tight text-black md:text-6xl">
+              <h1 className="mt-2 font-display text-4xl font-bold leading-tight text-black md:text-6xl">
                 {store.name}
               </h1>
               <p className='mt-3 text-lg text-black/70'>
@@ -208,7 +208,7 @@ export default function StoreDetail() {
               {kitchens.length > 0 && (
                 <div className='rounded-2xl border border-black/10 bg-white p-6 shadow-soft'>
                   <Eyebrow>In-store kitchens</Eyebrow>
-                  <h2 className="mt-1 font-['Oswald'] text-2xl font-bold text-black md:text-3xl">Hot, fresh, and fast.</h2>
+                  <h2 className="mt-1 font-display text-2xl font-bold text-black md:text-3xl">Hot, fresh, and fast.</h2>
                   <p className='mt-1 text-black/70'>Made-to-order, right inside this location.</p>
                   <div className='mt-4 grid grid-cols-1 gap-3 sm:grid-cols-2'>
                     {kitchens.map(k => {
@@ -242,7 +242,7 @@ export default function StoreDetail() {
 
               {amenities.length > 0 && (
                 <div className='rounded-2xl border border-black/10 bg-white p-6 shadow-soft'>
-                  <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">At this location</h2>
+                  <h2 className="font-display text-2xl font-bold text-black md:text-3xl">At this location</h2>
                   <ul className='mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3'>
                     {amenities.map(a => <AmenityRow key={a} label={a} />)}
                   </ul>
@@ -250,7 +250,7 @@ export default function StoreDetail() {
               )}
 
               <div className='rounded-2xl border border-black/10 bg-white p-6 shadow-soft'>
-                <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">Store hours</h2>
+                <h2 className="font-display text-2xl font-bold text-black md:text-3xl">Store hours</h2>
                 <table className='mt-3 w-full border-collapse'>
                   <tbody>
                     {DAY_ORDER.map(k => {
@@ -275,7 +275,7 @@ export default function StoreDetail() {
             {/* Find us */}
             <div className='lg:col-span-5'>
               <div className='rounded-2xl border border-black/10 bg-white p-6 shadow-soft'>
-                <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">Find us</h2>
+                <h2 className="font-display text-2xl font-bold text-black md:text-3xl">Find us</h2>
                 <div className='mt-3'>
                   <FindUsMap store={store} />
                 </div>
@@ -299,8 +299,8 @@ export default function StoreDetail() {
         {/* Store gallery — every shot from this store's folder */}
         {(MEDIA[store.slug]?.gallery?.length ?? 0) > 0 && (
           <section className='container mx-auto px-6 pb-10 md:px-10'>
-            <div className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">Store gallery</div>
-            <h2 className="mt-1 font-['Oswald'] text-2xl font-bold text-black md:text-3xl">Take a look around.</h2>
+            <div className="font-display tracking-wide text-xs uppercase text-brand">Store gallery</div>
+            <h2 className="mt-1 font-display text-2xl font-bold text-black md:text-3xl">Take a look around.</h2>
             <StoreGallery
               images={MEDIA[store.slug]!.gallery!}
               thumbs={MEDIA[store.slug]!.thumbs}
@@ -314,7 +314,7 @@ export default function StoreDetail() {
           <div className='flex flex-wrap items-center justify-between gap-5 rounded-2xl bg-gradient-to-r from-brand to-[#12205f] p-7 text-white shadow-soft'>
             <div>
               <Eyebrow light>Clarks Rewards</Eyebrow>
-              <h2 className="mt-1 font-['Oswald'] text-2xl font-bold md:text-3xl">Earn on every fill-up and snack.</h2>
+              <h2 className="mt-1 font-display text-2xl font-bold md:text-3xl">Earn on every fill-up and snack.</h2>
               <p className='mt-1 max-w-lg text-white/80'>
                 Redeem for free fuel, in-store savings, and members-only perks—all in the app.
               </p>
@@ -328,7 +328,7 @@ export default function StoreDetail() {
         {/* Nearby */}
         {nearby.length > 0 && (
           <section className='container mx-auto px-6 pb-16 md:px-10'>
-            <h2 className="font-['Oswald'] text-2xl font-bold text-black md:text-3xl">Other Clarks nearby</h2>
+            <h2 className="font-display text-2xl font-bold text-black md:text-3xl">Other Clarks nearby</h2>
             <div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
               {nearby.map(n => (
                 <Link
@@ -337,7 +337,7 @@ export default function StoreDetail() {
                   className='rounded-2xl border border-black/10 bg-white p-5 shadow-soft transition-transform hover:-translate-y-1'
                 >
                   <div className='text-sm text-black/50'>#{n.id} · {n.miles.toFixed(1)} mi away</div>
-                  <div className="mt-1 font-['Oswald'] text-xl font-bold text-black">{n.name}</div>
+                  <div className="mt-1 font-display text-xl font-bold text-black">{n.name}</div>
                   <div className='text-sm text-black/60'>{n.address} · {n.city}, {n.state}</div>
                 </Link>
               ))}

--- a/ClarksPNS/src/pages/StoreDetail.tsx
+++ b/ClarksPNS/src/pages/StoreDetail.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react'
 import type { ReactNode } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { SEO } from '@/lib/seo'
 import FindUsMap from '@/components/site/FindUsMap'
+import Forecourt3D from '@/components/site/Forecourt3D'
 import StoreGallery from '@/components/site/StoreGallery'
 import storeMedia from '@/content/store-media.json'
 import { FOOD_BRANDS } from '@/content/menus'
@@ -166,6 +168,7 @@ export default function StoreDetail() {
                     Call {store.phone}
                   </a>
                 )}
+                <MyStoreButton slug={store.slug} />
               </div>
             </div>
 
@@ -244,7 +247,11 @@ export default function StoreDetail() {
                 <div className='rounded-2xl border border-black/10 bg-white p-6 shadow-soft'>
                   <h2 className="font-display text-2xl font-bold text-black md:text-3xl">At this location</h2>
                   <ul className='mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3'>
-                    {amenities.map(a => <AmenityRow key={a} label={a} />)}
+                    {amenities.map(a => (
+                      <a key={a} href='#gallery' className='block' title='See it in the store gallery'>
+                        <AmenityRow label={a} />
+                      </a>
+                    ))}
                   </ul>
                 </div>
               )}
@@ -276,6 +283,9 @@ export default function StoreDetail() {
             <div className='lg:col-span-5'>
               <div className='rounded-2xl border border-black/10 bg-white p-6 shadow-soft'>
                 <h2 className="font-display text-2xl font-bold text-black md:text-3xl">Find us</h2>
+                <div className='mt-2'>
+                  <Forecourt3D store={store} />
+                </div>
                 <div className='mt-3'>
                   <FindUsMap store={store} />
                 </div>
@@ -299,7 +309,7 @@ export default function StoreDetail() {
         {/* Store gallery — every shot from this store's folder */}
         {(MEDIA[store.slug]?.gallery?.length ?? 0) > 0 && (
           <section className='container mx-auto px-6 pb-10 md:px-10'>
-            <div className="font-display tracking-wide text-xs uppercase text-brand">Store gallery</div>
+            <div id='gallery' className="font-display tracking-wide text-xs uppercase text-brand">Store gallery</div>
             <h2 className="mt-1 font-display text-2xl font-bold text-black md:text-3xl">Take a look around.</h2>
             <StoreGallery
               images={MEDIA[store.slug]!.gallery!}
@@ -346,5 +356,29 @@ export default function StoreDetail() {
         )}
       </main>
     </>
+  )
+}
+
+
+function MyStoreButton({ slug }: { slug: string }) {
+  const KEY = 'clarks-my-store'
+  const [mine, setMine] = useState(
+    () => typeof window !== 'undefined' && localStorage.getItem(KEY) === slug
+  )
+  return (
+    <button
+      type='button'
+      onClick={() => {
+        localStorage.setItem(KEY, slug)
+        setMine(true)
+      }}
+      className={
+        mine
+          ? 'inline-flex items-center justify-center rounded-2xl bg-[#2fd06f]/15 px-5 py-3 text-base font-medium text-[#1d7c44]'
+          : 'inline-flex items-center justify-center rounded-2xl border border-black/15 px-5 py-3 text-base font-medium text-black/70 transition-colors hover:border-brand hover:text-brand'
+      }
+    >
+      {mine ? 'Your Clark’s' : 'Make this my Clark’s'}
+    </button>
   )
 }

--- a/ClarksPNS/src/pages/Terms.tsx
+++ b/ClarksPNS/src/pages/Terms.tsx
@@ -13,10 +13,10 @@ export default function Terms() {
           }}
         />
         <div className='container mx-auto px-6 md:px-10 py-14 md:py-16 relative z-10'>
-          <p className="font-['Oswald'] tracking-wide text-xs uppercase text-white/80">
+          <p className="font-display tracking-wide text-xs uppercase text-white/80">
             Clark&apos;s Rewards
           </p>
-          <h1 className="mt-2 font-['Oswald'] text-3xl md:text-5xl font-bold leading-tight">
+          <h1 className="mt-2 font-display text-3xl md:text-5xl font-bold leading-tight">
             Terms & Conditions
           </h1>
           <p className="mt-2 text-sm text-white/80">
@@ -32,7 +32,7 @@ export default function Terms() {
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-4xl space-y-10 text-black/80'>
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 1. Program Overview
               </h2>
               <p className='mt-3 leading-7'>
@@ -46,7 +46,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 2. Membership Eligibility
               </h2>
               <ul className='mt-3 space-y-2 leading-7 list-disc pl-6'>
@@ -62,7 +62,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 3. Enrollment
               </h2>
               <ul className='mt-3 space-y-2 leading-7 list-disc pl-6'>
@@ -79,25 +79,25 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 4. Earning & Tracking Activity
               </h2>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">4.1 Visits</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">4.1 Visits</h3>
               <p className='mt-2 leading-7'>
                 Any time a member uses their loyalty account in-store or online, the member
                 will accrue one (1) visit in a wallet labeled &ldquo;Visits&rdquo; at checkout and close.
                 Members cannot accrue more than one (1) visit within a 60-minute period.
               </p>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">4.2 Dollars Spent</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">4.2 Dollars Spent</h3>
               <p className='mt-2 leading-7'>
                 Any time a member makes a purchase, the pre-tax amount spent will be added
                 to a wallet labeled &ldquo;Dollars Spent.&rdquo; This value is used to calculate points
                 earned for that transaction.
               </p>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">4.3 Points</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">4.3 Points</h3>
               <p className='mt-2 leading-7'>
                 Points may be awarded based on visits, dollars spent, or other promotional
                 rules established by Clark&apos;s from time to time. Points have no cash value,
@@ -117,14 +117,14 @@ export default function Terms() {
                 from earning points at its discretion.
               </p>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">4.4 Rewards</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">4.4 Rewards</h3>
               <p className='mt-2 leading-7'>
                 Any reward redeemed on the account will be tracked in the member&apos;s account.
                 Rewards are subject to availability and may be changed, substituted, or
                 removed at any time at Clark&apos;s discretion.
               </p>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">4.5 Fuel Reward Limitations</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">4.5 Fuel Reward Limitations</h3>
               <p className='mt-2 leading-7'>
                 Fuel discounts may be subject to per-transaction gallon limits, per-day usage
                 limits, or other operational restrictions, which will be disclosed at the time
@@ -135,7 +135,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 5. Registration Reward (Fuel Discount Ladder)
               </h2>
               <ul className='mt-3 space-y-2 leading-7 list-disc pl-6'>
@@ -164,7 +164,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 6. Bankable Points & Reward Redemption
               </h2>
               <ul className='mt-3 space-y-2 leading-7 list-disc pl-6'>
@@ -180,7 +180,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 7. Points Balance Cap
               </h2>
               <p className='mt-3 leading-7'>
@@ -202,7 +202,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 8. Points Expiration Based on Inactivity
               </h2>
               <p className='mt-3 leading-7'>
@@ -224,7 +224,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 9. Exclusions & Limitations
               </h2>
               <p className='mt-3 leading-7'>
@@ -243,7 +243,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 10. Account Misuse & Adjustments
               </h2>
               <p className='mt-3 leading-7'>
@@ -254,7 +254,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 11. Program Changes or Termination
               </h2>
               <p className='mt-3 leading-7'>
@@ -282,7 +282,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 12. SMS Text Messaging Terms
               </h2>
               <p className='mt-3 leading-7'>
@@ -317,7 +317,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 13. Disclaimer of Warranties; Limitation of Liability
               </h2>
               <p className='mt-3 leading-7'>
@@ -346,7 +346,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 14. Governing Law
               </h2>
               <p className='mt-3 leading-7'>
@@ -356,11 +356,11 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 15. Dispute Resolution; Exclusive Venue; Class Action Waiver
               </h2>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">15.1 Exclusive Venue</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">15.1 Exclusive Venue</h3>
               <p className='mt-2 leading-7'>
                 Except where prohibited by law, any dispute, claim, or controversy arising out
                 of or relating to the Program, these Terms & Conditions, or your participation
@@ -373,20 +373,20 @@ export default function Terms() {
                 over Boyd County, Kentucky.
               </p>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">15.2 Waiver of Class Actions</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">15.2 Waiver of Class Actions</h3>
               <p className='mt-2 leading-7'>
                 You agree that any dispute shall be brought solely in your individual capacity
                 and not as a class action, consolidated action, or representative action.
                 You waive any right to participate in a class action lawsuit.
               </p>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">15.3 Waiver of Jury Trial</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">15.3 Waiver of Jury Trial</h3>
               <p className='mt-2 leading-7'>
                 To the fullest extent permitted by law, you waive any right to a jury trial in
                 any dispute arising out of or relating to the Program.
               </p>
 
-              <h3 className="mt-4 font-['Oswald'] text-xl font-bold text-black">15.4 Severability</h3>
+              <h3 className="mt-4 font-display text-xl font-bold text-black">15.4 Severability</h3>
               <p className='mt-2 leading-7'>
                 If any portion of this dispute resolution provision is found unenforceable, the
                 remaining portions shall remain in full force and effect to the fullest extent
@@ -395,7 +395,7 @@ export default function Terms() {
             </div>
 
             <div>
-              <h2 className="font-['Oswald'] text-2xl md:text-3xl font-bold text-black">
+              <h2 className="font-display text-2xl md:text-3xl font-bold text-black">
                 16. Contact Information
               </h2>
               <p className='mt-3 leading-7'>

--- a/ClarksPNS/src/pages/clarksrewards.tsx
+++ b/ClarksPNS/src/pages/clarksrewards.tsx
@@ -10,6 +10,8 @@ import { DesktopHero } from '@/components/site/DesktopHero'
 
 // Assets
 import rewardsPoster from '@/assets/images/clarkshero.png'
+import rodneyRanger from '@/assets/images/RodneyTB.png'
+import { IconPump, IconCoffee, IconGift } from '@/components/site/Icons'
 import rewardsVideo from '@/assets/videos/RewardsRangerVideo.mp4'
 import appPhone from '@/assets/images/clarksrewards.jpg' // promo image of the app
 import RewardsPageVideoAd from '@/assets/videos/ClarksRewardsPhoneAnimation1080pblack.mp4'
@@ -186,7 +188,7 @@ export default function ClarksRewards () {
                     aria-hidden
                     className='inline-flex h-12 w-12 items-center justify-center rounded-xl bg-brand/10'
                   >
-                    <b className='text-xl'>{b.icon}</b>
+                    <b.icon className='h-6 w-6 text-brand' />
                   </span>
                 </div>
                 <h3 className="font-['Oswald'] text-xl font-bold text-black">
@@ -197,6 +199,61 @@ export default function ClarksRewards () {
                 </p>
               </article>
             ))}
+          </div>
+        </div>
+      </section>
+
+      {/* === The math — real earn rates === */}
+      <section aria-label='How points add up' className='py-12 md:py-20 bg-brand text-white'>
+        <div className='container mx-auto px-6 md:px-10'>
+          <div className='max-w-3xl'>
+            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold">
+              The math is simple.
+            </h2>
+            <p className='mt-2 text-white/85 text-base md:text-lg'>
+              Every dollar and every gallon works for you — then trade points
+              for cents-off fuel or free favorites like a sausage biscuit.
+            </p>
+          </div>
+          <div className='mt-10 grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-5xl'>
+            <RateCard n={10} unit='points' per='per $1 in store' />
+            <RateCard n={20} unit='points' per='per gallon of fuel' />
+            <RateCard n={0} unit='cost to join' per='free in the app, day one' isZero />
+          </div>
+        </div>
+      </section>
+
+      {/* === Rodney, the Rewards Ranger === */}
+      <section aria-label='Rodney the Rewards Ranger' className='relative overflow-hidden py-14 md:py-20 bg-white border-b border-black/10'>
+        <div aria-hidden className='pointer-events-none absolute inset-y-0 left-[-10%] w-[70%] opacity-[0.05]'
+          style={{ background: 'repeating-linear-gradient(90deg, #263B95 0 3px, transparent 3px 42px)' }} />
+        <div className='container relative mx-auto px-6 md:px-10'>
+          <div className='grid grid-cols-1 lg:grid-cols-12 items-center gap-10'>
+            <div className='lg:col-span-5 order-2 lg:order-1'>
+              <div className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">Your points, protected</div>
+              <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+                Ride with Rodney, the Rewards Ranger.
+              </h2>
+              <p className='mt-3 text-black/70 max-w-prose'>
+                Rodney rides ahead so you never miss a boost — weekly point
+                multipliers, members-only drops, and surprise perks at the
+                pump. Saddle up in the app and he does the rest.
+              </p>
+              <Link
+                to='https://clarkspumpnshop.myguestaccount.com/en-us/guest/enroll?card-template=JTIldXJsLXBhcmFtLWFlcy1rZXklYzR0UXJrdXQzZmVRb1laWCU3WVNiTW1LeDN4TmhrRGdGV3dCMmxPMD0%3D&template=0'
+                className='mt-6 inline-flex items-center justify-center rounded-2xl bg-brand px-6 py-3 text-white hover:bg-brand/90 transition-colors'
+              >
+                Join the ride
+              </Link>
+            </div>
+            <div className='lg:col-span-7 order-1 lg:order-2'>
+              <div className='relative mx-auto max-w-[520px]'>
+                <div aria-hidden className='absolute right-[62%] top-[38%] h-1.5 w-24 rounded-full bg-brand/25 rodney-line' />
+                <div aria-hidden className='absolute right-[68%] top-[52%] h-1.5 w-36 rounded-full bg-brand/15 rodney-line rodney-line-2' />
+                <div aria-hidden className='absolute right-[60%] top-[66%] h-1.5 w-16 rounded-full bg-brand/20 rodney-line rodney-line-3' />
+                <img src={rodneyRanger} alt='Rodney, the Clark’s Rewards Ranger' className='relative w-full h-auto rodney-ride' loading='lazy' />
+              </div>
+            </div>
           </div>
         </div>
       </section>
@@ -382,19 +439,50 @@ export default function ClarksRewards () {
   )
 }
 
+function RateCard ({ n, unit, per, isZero }: { n: number; unit: string; per: string; isZero?: boolean }) {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [val, setVal] = useState(0)
+  useEffect(() => {
+    const el = ref.current
+    if (!el) return
+    const reduced = window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches
+    const io = new IntersectionObserver(es => {
+      if (!es.some(e => e.isIntersecting)) return
+      io.disconnect()
+      if (reduced || isZero) { setVal(n); return }
+      const t0 = performance.now()
+      const tick = (t: number) => {
+        const p = Math.min((t - t0) / 1200, 1)
+        setVal(Math.round(n * (1 - Math.pow(1 - p, 3))))
+        if (p < 1) requestAnimationFrame(tick)
+      }
+      requestAnimationFrame(tick)
+    }, { threshold: 0.5 })
+    io.observe(el)
+    return () => io.disconnect()
+  }, [n, isZero])
+  return (
+    <div ref={ref} className='rounded-2xl bg-white/10 border border-white/15 p-6'>
+      <div className="font-['Oswald'] text-5xl font-bold tabular-nums">{isZero ? '$0' : val}</div>
+      <div className='mt-1 font-medium'>{unit}</div>
+      <div className='text-white/75 text-sm'>{per}</div>
+    </div>
+  )
+}
+
 const BENEFITS = [
   {
-    icon: '⛽',
+    icon: IconPump,
     title: 'Fuel savings',
     desc: 'Redeem points at the pump for instant cents-off per gallon.'
   },
   {
-    icon: '☕',
+    icon: IconCoffee,
     title: 'Coffee & snacks',
     desc: 'Daily deals on hot coffee, fountain drinks, and fresh snacks.'
   },
   {
-    icon: '🎁',
+    icon: IconGift,
     title: 'Bonus boosts',
     desc: 'Multiply earnings during weekly Boosts and seasonal events.'
   }

--- a/ClarksPNS/src/pages/clarksrewards.tsx
+++ b/ClarksPNS/src/pages/clarksrewards.tsx
@@ -12,6 +12,7 @@ import { DesktopHero } from '@/components/site/DesktopHero'
 import rewardsPoster from '@/assets/images/clarkshero.png'
 import rodneyRanger from '@/assets/images/RodneyTB.png'
 import { IconPump, IconCoffee, IconGift } from '@/components/site/Icons'
+import Tilt from '@/components/site/Tilt'
 import rewardsVideo from '@/assets/videos/RewardsRangerVideo.mp4'
 import appPhone from '@/assets/images/clarksrewards.jpg' // promo image of the app
 import RewardsPageVideoAd from '@/assets/videos/ClarksRewardsPhoneAnimation1080pblack.mp4'
@@ -179,9 +180,9 @@ export default function ClarksRewards () {
 
           <div className='mt-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto'>
             {BENEFITS.map(b => (
+              <Tilt key={b.title}>
               <article
-                key={b.title}
-                className='rounded-2xl border border-black/10 p-6 hover:shadow-md transition-shadow bg-white'
+                className='rounded-2xl border border-black/10 brand-topline p-6 hover:shadow-md transition-shadow bg-white'
               >
                 <div className='mb-4'>
                   <span
@@ -198,13 +199,14 @@ export default function ClarksRewards () {
                   {b.desc}
                 </p>
               </article>
+              </Tilt>
             ))}
           </div>
         </div>
       </section>
 
       {/* === The math — real earn rates === */}
-      <section aria-label='How points add up' className='py-12 md:py-20 bg-brand text-white'>
+      <section aria-label='How points add up' className='py-12 md:py-20 bg-brand brand-stripes text-white'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
             <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold">

--- a/ClarksPNS/src/pages/clarksrewards.tsx
+++ b/ClarksPNS/src/pages/clarksrewards.tsx
@@ -12,6 +12,7 @@ import { DesktopHero } from '@/components/site/DesktopHero'
 import rewardsPoster from '@/assets/images/clarkshero.png'
 import rodneyRanger from '@/assets/images/RodneyTB.png'
 import { IconPump, IconCoffee, IconGift } from '@/components/site/Icons'
+import { track } from '@/lib/track'
 import Tilt from '@/components/site/Tilt'
 import rewardsVideo from '@/assets/videos/RewardsRangerVideo.mp4'
 import appPhone from '@/assets/images/clarksrewards.jpg' // promo image of the app
@@ -139,6 +140,7 @@ export default function ClarksRewards () {
                   <div className='flex flex-col sm:flex-row gap-3 sm:gap-4'>
                     <Link
                       to='https://clarkspumpnshop.myguestaccount.com/en-us/guest/enroll?card-template=JTIldXJsLXBhcmFtLWFlcy1rZXklYzR0UXJrdXQzZmVRb1laWCU3WVNiTW1LeDN4TmhrRGdGV3dCMmxPMD0%3D&template=0'
+                      onClick={() => track('rewards_join_click', { placement: 'hero' })}
                       className='inline-flex items-center justify-center rounded-2xl px-6 py-3 text-white bg-brand hover:bg-brand/90 transition-all shadow-lg shadow-black/20 text-base md:text-lg'
                     >
                       Join Clarks Rewards

--- a/ClarksPNS/src/pages/clarksrewards.tsx
+++ b/ClarksPNS/src/pages/clarksrewards.tsx
@@ -222,6 +222,7 @@ export default function ClarksRewards () {
             <RateCard n={20} unit='points' per='per gallon of fuel' />
             <RateCard n={0} unit='cost to join' per='free in the app, day one' isZero />
           </div>
+          <PointsSim />
         </div>
       </section>
 
@@ -438,6 +439,37 @@ export default function ClarksRewards () {
       </section>
     </main>
     </>
+  )
+}
+
+function PointsSim () {
+  const [gal, setGal] = useState(12)
+  const [spend, setSpend] = useState(20)
+  const yearly = Math.round((gal * 20 + spend * 10) * 52)
+  return (
+    <div className='mt-10 max-w-5xl rounded-2xl border border-white/15 bg-white/10 p-6 md:p-8'>
+      <h3 className='font-display text-2xl md:text-3xl'>Your year in points</h3>
+      <div className='mt-6 grid grid-cols-1 gap-8 md:grid-cols-3'>
+        <label className='block'>
+          <div className='flex items-baseline justify-between text-sm text-white/80'>
+            <span>Gallons per week</span>
+            <span className='font-display text-xl text-white tabular-nums'>{gal}</span>
+          </div>
+          <input type='range' min={0} max={40} value={gal} onChange={e => setGal(+e.target.value)} className='mt-2 w-full accent-white' />
+        </label>
+        <label className='block'>
+          <div className='flex items-baseline justify-between text-sm text-white/80'>
+            <span>In-store $ per week</span>
+            <span className='font-display text-xl text-white tabular-nums'>${spend}</span>
+          </div>
+          <input type='range' min={0} max={100} value={spend} onChange={e => setSpend(+e.target.value)} className='mt-2 w-full accent-white' />
+        </label>
+        <div className='text-center md:text-right'>
+          <div className='font-display text-5xl leading-none text-white tabular-nums md:text-6xl'>{yearly.toLocaleString()}</div>
+          <div className='mt-1 text-sm text-white/75'>points a year — redeem for cents-off fuel and free favorites</div>
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/ClarksPNS/src/pages/clarksrewards.tsx
+++ b/ClarksPNS/src/pages/clarksrewards.tsx
@@ -129,7 +129,7 @@ export default function ClarksRewards () {
             <div className='container mx-auto h-full px-6 md:px-10'>
               <div className='flex h-full items-center'>
                 <div className='inline-flex flex-col gap-4 md:gap-6 max-w-[680px]'>
-                  <h1 className="font-['Oswald'] font-bold text-white drop-shadow-[0_1px_12px_rgba(0,0,0,0.35)] text-4xl md:text-6xl leading-tight">
+                  <h1 className="font-display font-bold text-white drop-shadow-[0_1px_12px_rgba(0,0,0,0.35)] text-4xl md:text-6xl leading-tight">
                     Join Clarks Rewards
                   </h1>
                   <p className='text-white/95 drop-shadow-[0_1px_8px_rgba(0,0,0,0.35)] text-lg md:text-2xl max-w-prose'>
@@ -170,7 +170,7 @@ export default function ClarksRewards () {
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               Perks you’ll actually use
             </h2>
             <p className='mt-2 text-black/70 text-base md:text-lg'>
@@ -192,7 +192,7 @@ export default function ClarksRewards () {
                     <b.icon className='h-6 w-6 text-brand' />
                   </span>
                 </div>
-                <h3 className="font-['Oswald'] text-xl font-bold text-black">
+                <h3 className="font-display text-xl font-bold text-black">
                   {b.title}
                 </h3>
                 <p className='mt-2 text-black/70 text-sm leading-relaxed'>
@@ -209,7 +209,7 @@ export default function ClarksRewards () {
       <section aria-label='How points add up' className='py-12 md:py-20 bg-brand brand-stripes text-white'>
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold">
+            <h2 className="font-display text-3xl md:text-4xl font-bold">
               The math is simple.
             </h2>
             <p className='mt-2 text-white/85 text-base md:text-lg'>
@@ -232,8 +232,8 @@ export default function ClarksRewards () {
         <div className='container relative mx-auto px-6 md:px-10'>
           <div className='grid grid-cols-1 lg:grid-cols-12 items-center gap-10'>
             <div className='lg:col-span-5 order-2 lg:order-1'>
-              <div className="font-['Oswald'] tracking-wide text-xs uppercase text-brand">Your points, protected</div>
-              <h2 className="mt-1 font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+              <div className="font-display tracking-wide text-xs uppercase text-brand">Your points, protected</div>
+              <h2 className="mt-1 font-display text-3xl md:text-4xl font-bold text-black">
                 Ride with Rodney, the Rewards Ranger.
               </h2>
               <p className='mt-3 text-black/70 max-w-prose'>
@@ -263,7 +263,7 @@ export default function ClarksRewards () {
       {/* === Featured Video (between Perks and How it Works) === */}
       <section
         aria-label='Rewards Spotlight Video'
-        className='py-10 md:py-16 bg-neutral-50 border-y border-black/10'
+        className='band-night brand-stripes py-10 md:py-16 text-white'
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='mx-auto w-full max-w-6xl rounded-2xl overflow-hidden border border-black/10 shadow-sm bg-black'>
@@ -290,7 +290,7 @@ export default function ClarksRewards () {
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               How it works
             </h2>
             <p className='mt-2 text-black/70 text-base md:text-lg'>
@@ -307,7 +307,7 @@ export default function ClarksRewards () {
                 <div className='absolute -top-3 -left-3 flex h-10 w-10 items-center justify-center rounded-xl bg-brand text-white font-bold'>
                   {i + 1}
                 </div>
-                <h3 className="font-['Oswald'] text-xl font-bold text-black pl-8">
+                <h3 className="font-display text-xl font-bold text-black pl-8">
                   {s.title}
                 </h3>
                 <p className='mt-2 text-black/70 text-sm leading-relaxed pl-8'>
@@ -335,7 +335,7 @@ export default function ClarksRewards () {
             {/* LEFT: Text — positioned lower as requested */}
             <div className='order-2 lg:order-1 relative z-20 flex items-start'>
               <div className='max-w-lg mt-16 md:mt-24 lg:mt-32 pb-16 md:pb-20 lg:pb-28'>
-                <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+                <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
                   The Clarks Rewards App
                 </h2>
                 <p className='mt-3 text-black/70 text-base md:text-lg'>
@@ -408,7 +408,7 @@ export default function ClarksRewards () {
       >
         <div className='container mx-auto px-6 md:px-10'>
           <div className='max-w-3xl'>
-            <h2 className="font-['Oswald'] text-3xl md:text-4xl font-bold text-black">
+            <h2 className="font-display text-3xl md:text-4xl font-bold text-black">
               Frequently asked questions
             </h2>
             <p className='mt-2 text-black/70 text-base md:text-lg'>
@@ -422,7 +422,7 @@ export default function ClarksRewards () {
                 key={f.q}
                 className='group rounded-2xl bg-white p-6 border border-black/10 open:shadow-md'
               >
-                <summary className="cursor-pointer list-none font-['Oswald'] text-lg font-bold text-black flex items-center justify-between">
+                <summary className="cursor-pointer list-none font-display text-lg font-bold text-black flex items-center justify-between">
                   {f.q}
                   <span className='ml-4 inline-flex h-7 w-7 items-center justify-center rounded-lg bg-neutral-100 group-open:rotate-45 transition-transform'>
                     +
@@ -465,7 +465,7 @@ function RateCard ({ n, unit, per, isZero }: { n: number; unit: string; per: str
   }, [n, isZero])
   return (
     <div ref={ref} className='rounded-2xl bg-white/10 border border-white/15 p-6'>
-      <div className="font-['Oswald'] text-5xl font-bold tabular-nums">{isZero ? '$0' : val}</div>
+      <div className="font-display text-5xl font-bold tabular-nums">{isZero ? '$0' : val}</div>
       <div className='mt-1 font-medium'>{unit}</div>
       <div className='text-white/75 text-sm'>{per}</div>
     </div>

--- a/ClarksPNS/tailwind.config.js
+++ b/ClarksPNS/tailwind.config.js
@@ -66,9 +66,9 @@ module.exports = {
       },
     },
     fontFamily: {
-      sans: ['Oswald', 'system-ui', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'ui-sans-serif', 'sans-serif'],
+      sans: ['Inter', 'system-ui', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'ui-sans-serif', 'sans-serif'],
       display: ['Oswald', 'ui-sans-serif', 'system-ui'],
-      body: ['Oswald', 'ui-sans-serif', 'system-ui'],
+      body: ['Inter', 'ui-sans-serif', 'system-ui'],
     },
   },
   plugins: [],

--- a/ClarksPNS/tailwind.config.js
+++ b/ClarksPNS/tailwind.config.js
@@ -67,7 +67,7 @@ module.exports = {
     },
     fontFamily: {
       sans: ['Inter', 'system-ui', 'Segoe UI', 'Roboto', 'Helvetica', 'Arial', 'ui-sans-serif', 'sans-serif'],
-      display: ['Oswald', 'ui-sans-serif', 'system-ui'],
+      display: ['"Bebas Neue"', 'Oswald', 'ui-sans-serif', 'system-ui'],
       body: ['Inter', 'ui-sans-serif', 'system-ui'],
     },
   },


### PR DESCRIPTION
Thirteen commits of sitewide elevation, reviewed by Seth in local preview: Bebas/Inter type system, SVG icons (zero emojis), night/brand/paper section modes, brand-lockup hero, night footer, quick-links bar + site search, LIVE 63-store ticker (price slot reserved), notice.json banner system, weather-aware touches, /community + /scholarship + /fleet pages, Beacon Map, Road Trip finder, 3D forecourt models, my-Clark's memory, dynamic Food with daypart, calculators on real rates, wash tunnel, 3D gift cards, per-store og:image share cards, conversion events, ATLAS-INTEGRATION.md. Content rules per client: no prices, no anniversary claims, 63 stores, closed store removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)