### PR TITLE
Mobile: search button in the phone header

### DIFF
--- a/ClarksPNS/src/components/site/HeaderNav.tsx
+++ b/ClarksPNS/src/components/site/HeaderNav.tsx
@@ -4,6 +4,7 @@ import { Link, NavLink, useLocation } from 'react-router-dom'
 import LiveTicker from '@/components/site/LiveTicker'
 import SearchOverlay from '@/components/site/SearchOverlay'
 import NoticeBanner from '@/components/site/NoticeBanner'
+import { IconSearch } from '@/components/site/Icons'
 import MobileMenuDrawer from './MobileMenuDrawer'
 import logoUrl from '@/assets/images/clarks-logo.png'
 import rewardsLogoUrl from '@/assets/images/Clarks-PNS-Main-Rewards-Logo-Cropped.png'
@@ -143,7 +144,16 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
           </Link>
           {/* empty center cell */}
           <div />
-          {/* hamburger on right */}
+          {/* search + hamburger on right */}
+          <div className='flex items-center gap-1'>
+          <button
+            type='button'
+            aria-label='Search'
+            onClick={() => setSearchOpen(true)}
+            className='h-11 w-11 grid place-items-center rounded-md text-black hover:opacity-80'
+          >
+            <IconSearch className='h-5 w-5' />
+          </button>
           <button
             aria-label='Open menu'
             aria-expanded={open}
@@ -152,6 +162,7 @@ export default function HeaderNav ({ showAccentBar = true }: HeaderNavProps) {
           >
             <HamburgerIcon className='h-5 w-5' />
           </button>
+          </div>
         </div>
 
         {/* --- DESKTOP BAR (md+) --- */}

--- a/ClarksPNS/src/components/site/Icons.tsx
+++ b/ClarksPNS/src/components/site/Icons.tsx
@@ -116,3 +116,12 @@ export function IconCap(props: P) {
     </svg>
   )
 }
+
+export function IconSearch(props: P) {
+  return (
+    <svg {...base} {...props}>
+      <circle cx='11' cy='11' r='6.5' />
+      <path d='M15.8 15.8 21 21' />
+    </svg>
+  )
+}


### PR DESCRIPTION
Search was unreachable on phones (quick-links bar is md+). Magnifier icon now sits beside the hamburger; overlay verified at 375px. Mobile pass otherwise clean: hero, ticker, cinema cards, beacon map, wash page, weather strip all verified at phone size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)