### PR TITLE
Live fix: real map for beacons + customer-facing homepage copy

### DIFF
--- a/ClarksPNS/src/components/site/BeaconMap.tsx
+++ b/ClarksPNS/src/components/site/BeaconMap.tsx
@@ -1,160 +1,103 @@
-// The Beacon Map — every store plotted at its REAL coordinates on a
-// canvas nightscape. Beacons pulse (green open / red closed from live
-// hours), hover names the store, click goes to its page.
-import { useEffect, useRef, useState } from 'react'
+// The Beacon Map — a real Google Map in Clark's night styling. Every
+// store is a glowing pin at its exact coordinates: green = open right
+// now (computed from real hours), red = closed. Click a pin to open
+// that store's page. Renders nothing if the Maps key is unavailable.
+import { useMemo } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { allStores, openNow, type Store } from '@/lib/stores'
+import { GoogleMap, Marker, useJsApiLoader } from '@react-google-maps/api'
+import { allStores, openNow } from '@/lib/stores'
 
-type Plot = { store: Store; x: number; y: number; open: boolean; ph: number }
+const GOOGLE_KEY = (
+  import.meta.env.VITE_GOOGLE_MAPS_API_KEY as string | undefined
+)?.trim()
+
+const LIBRARIES: 'places'[] = ['places']
+const CENTER = { lat: 38.35, lng: -83.6 }
+
+/** Clark's night styling — navy world, readable state and city labels. */
+const NIGHT_STYLES: google.maps.MapTypeStyle[] = [
+  { elementType: 'geometry', stylers: [{ color: '#101c4d' }] },
+  { elementType: 'labels.text.fill', stylers: [{ color: '#8fa0c9' }] },
+  { elementType: 'labels.text.stroke', stylers: [{ color: '#0b153a' }] },
+  { featureType: 'administrative.country', elementType: 'geometry.stroke', stylers: [{ color: '#4a5a8f' }] },
+  { featureType: 'administrative.province', elementType: 'geometry.stroke', stylers: [{ color: '#5b6ca6' }, { weight: 1.5 }] },
+  { featureType: 'administrative.locality', elementType: 'labels.text.fill', stylers: [{ color: '#b8c4e6' }] },
+  { featureType: 'poi', stylers: [{ visibility: 'off' }] },
+  { featureType: 'road', elementType: 'geometry', stylers: [{ color: '#1b2f7d' }] },
+  { featureType: 'road', elementType: 'labels', stylers: [{ visibility: 'off' }] },
+  { featureType: 'road.highway', elementType: 'geometry', stylers: [{ color: '#2a3f8f' }] },
+  { featureType: 'transit', stylers: [{ visibility: 'off' }] },
+  { featureType: 'water', elementType: 'geometry', stylers: [{ color: '#0b153a' }] },
+  { featureType: 'water', elementType: 'labels.text.fill', stylers: [{ color: '#5b6ca6' }] }
+]
 
 export default function BeaconMap() {
-  const wrapRef = useRef<HTMLDivElement | null>(null)
-  const cvRef = useRef<HTMLCanvasElement | null>(null)
-  const plotsRef = useRef<Plot[]>([])
-  const [hover, setHover] = useState<Plot | null>(null)
   const navigate = useNavigate()
 
-  useEffect(() => {
-    const cv = cvRef.current
-    const wrap = wrapRef.current
-    if (!cv || !wrap) return
-    const ctx = cv.getContext('2d')
-    if (!ctx) return
+  if (!GOOGLE_KEY) return null
+  return <BeaconMapInner onOpen={slug => navigate(`/locations/${slug}`)} />
+}
 
-    const stores = allStores.filter(
-      s => s.lat != null && s.lng != null
-    ) as Array<Store & { lat: number; lng: number }>
+function BeaconMapInner({ onOpen }: { onOpen: (slug: string) => void }) {
+  const { isLoaded } = useJsApiLoader({
+    id: 'clarks-maps',
+    googleMapsApiKey: GOOGLE_KEY as string,
+    libraries: LIBRARIES
+  })
 
-    let W = 0
-    let H = 0
-    const dpr = window.devicePixelRatio || 1
+  const pins = useMemo(
+    () =>
+      allStores
+        .filter(s => s.lat != null && s.lng != null)
+        .map(s => ({ store: s, open: openNow(s).open !== false })),
+    []
+  )
 
-    const layout = () => {
-      const r = wrap.getBoundingClientRect()
-      W = cv.width = r.width * dpr
-      H = cv.height = 420 * dpr
-      cv.style.height = '420px'
-      const lats = stores.map(s => s.lat)
-      const lngs = stores.map(s => s.lng)
-      const minLat = Math.min(...lats)
-      const maxLat = Math.max(...lats)
-      const minLng = Math.min(...lngs)
-      const maxLng = Math.max(...lngs)
-      const pad = 0.08
-      plotsRef.current = stores.map((s, i) => ({
-        store: s,
-        x:
-          ((s.lng - minLng) / (maxLng - minLng)) * W * (1 - 2 * pad) + W * pad,
-        y:
-          ((maxLat - s.lat) / (maxLat - minLat)) * H * (1 - 2 * pad) + H * pad,
-        open: openNow(s).open !== false,
-        ph: (i * 0.61) % (Math.PI * 2)
-      }))
-    }
-    layout()
-    window.addEventListener('resize', layout)
-
-    const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches
-    let raf = 0
-    const draw = (t: number) => {
-      ctx.clearRect(0, 0, W, H)
-      // faint highway web: connect each beacon to its nearest neighbor
-      ctx.strokeStyle = 'rgba(0,132,255,0.14)'
-      ctx.lineWidth = 1 * dpr
-      const ps = plotsRef.current
-      for (const p of ps) {
-        let best: Plot | null = null
-        let bd = Infinity
-        for (const q of ps) {
-          if (q === p) continue
-          const d = (q.x - p.x) ** 2 + (q.y - p.y) ** 2
-          if (d < bd) {
-            bd = d
-            best = q
-          }
-        }
-        if (best) {
-          ctx.beginPath()
-          ctx.moveTo(p.x, p.y)
-          ctx.lineTo(best.x, best.y)
-          ctx.stroke()
-        }
-      }
-      // beacons
-      for (const p of ps) {
-        const pulse = reduced ? 0.8 : 0.55 + 0.45 * Math.sin(t / 800 + p.ph)
-        const col = p.open ? '47,208,111' : '255,77,77'
-        const g = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, 14 * dpr)
-        g.addColorStop(0, `rgba(${col},${0.5 * pulse})`)
-        g.addColorStop(1, `rgba(${col},0)`)
-        ctx.fillStyle = g
-        ctx.beginPath()
-        ctx.arc(p.x, p.y, 14 * dpr, 0, 7)
-        ctx.fill()
-        ctx.fillStyle = `rgba(${col},1)`
-        ctx.beginPath()
-        ctx.arc(p.x, p.y, 3 * dpr, 0, 7)
-        ctx.fill()
-      }
-      if (!reduced) raf = requestAnimationFrame(draw)
-    }
-    if (reduced) draw(0)
-    else raf = requestAnimationFrame(draw)
-
-    return () => {
-      cancelAnimationFrame(raf)
-      window.removeEventListener('resize', layout)
-    }
-  }, [])
-
-  const locate = (e: React.MouseEvent): Plot | null => {
-    const cv = cvRef.current
-    if (!cv) return null
-    const r = cv.getBoundingClientRect()
-    const dpr = window.devicePixelRatio || 1
-    const mx = (e.clientX - r.left) * dpr
-    const my = (e.clientY - r.top) * dpr
-    let best: Plot | null = null
-    let bd = Infinity
-    for (const p of plotsRef.current) {
-      const d = (p.x - mx) ** 2 + (p.y - my) ** 2
-      if (d < bd) {
-        bd = d
-        best = p
-      }
-    }
-    return best && bd < (16 * dpr) ** 2 ? best : null
+  if (!isLoaded) {
+    return (
+      <div className='grid h-[420px] w-full place-items-center rounded-2xl border border-white/15 bg-white/5 text-sm text-white/60'>
+        Lighting the beacons…
+      </div>
+    )
   }
 
   return (
-    <div ref={wrapRef} className='relative'>
-      <canvas
-        ref={cvRef}
-        className='block w-full cursor-pointer rounded-2xl border border-white/15'
-        onMouseMove={e => setHover(locate(e))}
-        onMouseLeave={() => setHover(null)}
-        onClick={e => {
-          const p = locate(e)
-          if (p) navigate(`/locations/${p.store.slug}`)
-        }}
-        aria-label='Map of every Clark’s location — click a beacon to open its store page'
-      />
-      {hover && (
-        <div className='pointer-events-none absolute left-1/2 top-3 -translate-x-1/2 rounded-xl bg-[#0b153a] px-4 py-2 text-center shadow-lg ring-1 ring-white/20'>
-          <div className='font-display text-lg leading-none text-white'>
-            {hover.store.name}
-          </div>
-          <div className='text-xs text-white/70'>
-            {hover.store.city}, {(hover.store.state || '').toUpperCase()} ·{' '}
-            <span className={hover.open ? 'text-[#8be3ae]' : 'text-[#ff8a8a]'}>
-              {hover.open ? 'OPEN' : 'CLOSED'}
-            </span>
-          </div>
-        </div>
-      )}
+    <div>
+      <div className='overflow-hidden rounded-2xl border border-white/15'>
+        <GoogleMap
+          mapContainerStyle={{ width: '100%', height: '420px' }}
+          center={CENTER}
+          zoom={7}
+          options={{
+            styles: NIGHT_STYLES,
+            disableDefaultUI: true,
+            zoomControl: true,
+            gestureHandling: 'cooperative',
+            backgroundColor: '#0b153a'
+          }}
+        >
+          {pins.map(({ store, open }) => (
+            <Marker
+              key={store.slug}
+              position={{ lat: store.lat as number, lng: store.lng as number }}
+              title={`${store.name} — ${store.city}, ${(store.state || '').toUpperCase()} (${open ? 'open now' : 'closed'})`}
+              onClick={() => onOpen(store.slug)}
+              icon={{
+                path: google.maps.SymbolPath.CIRCLE,
+                scale: 7,
+                fillColor: open ? '#2fd06f' : '#ff4d4d',
+                fillOpacity: 0.95,
+                strokeColor: '#ffffff',
+                strokeOpacity: 0.7,
+                strokeWeight: 1.5
+              }}
+            />
+          ))}
+        </GoogleMap>
+      </div>
       <div className='mt-2 text-center text-xs text-white/50'>
-        Every beacon is a real Clark’s at its exact coordinates — green is
-        open right now. Click one to visit the store.
+        Every pin is a real Clark’s — green means open right now. Tap one
+        to visit that store.
       </div>
     </div>
   )

--- a/ClarksPNS/src/components/site/HometownCinema.tsx
+++ b/ClarksPNS/src/components/site/HometownCinema.tsx
@@ -105,15 +105,15 @@ export default function HometownCinema() {
 
       <div className='container relative z-[1] mx-auto px-6 py-20 md:px-10 md:py-28'>
         <div className="font-display text-xs uppercase tracking-[0.3em] text-white/70">
-          Filmed over our own stores
+          Across the Tri-State
         </div>
         <h2 className="mt-2 font-display text-4xl font-bold leading-tight md:text-6xl">
           Proudly serving you.
         </h2>
         <p className='mt-4 max-w-prose text-lg text-white/85'>
-          Kentucky. Ohio. West Virginia. Every Clark’s has its own page —
-          real photos, real video, live hours, and a map that knows how far
-          away you are.
+          Kentucky. Ohio. West Virginia. Sixty-three stores, one promise —
+          hot food, friendly faces, and a clean stop every time. Wherever
+          the road takes you, there’s a Clark’s close by. Come see us.
         </p>
 
         {/* Showcase cards */}


### PR DESCRIPTION
Beacon canvas replaced with a night-styled real Google Map (state lines, city labels, 63 live status pins, click-through). Cinema band copy rewritten as a customer call-to-action. Verified locally with key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)